### PR TITLE
chore(deps): update pinned GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload ESLint SARIF
         if: ${{ !cancelled() && steps.eslint.outcome != 'skipped' }}
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: eslint.sarif
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
@@ -54,7 +54,7 @@ jobs:
         run: tar -czf spectra.tar.gz -C dist .
 
       - name: Login to registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |


### PR DESCRIPTION
## Summary

Consolidates the open GitHub Actions update PRs into one verified change. Pins are bumped to current digests across both workflows.

| Action | From | To |
| --- | --- | --- |
| actions/setup-node | v6.2.0 | v6.4.0 |
| github/codeql-action/upload-sarif | v4.32.6 | v4.36.2 |
| docker/login-action | v3.6.0 | **v4.2.0** |
| docker/metadata-action | v5.10.0 | **v6.1.0** |

`actions/setup-node` is bumped in both `ci.yaml` and `release-please.yaml`. The others apply to the workflow where they are used.

The `docker/login-action` v4 and `docker/metadata-action` v6 inputs used here (`registry`/`username`/`password`, `images`/`tags`) are unchanged from the previous majors, so no workflow logic changes are needed. The digests match what Renovate proposed.

## Supersedes
Replaces the individual Renovate PRs: #103, #115, #104, #106. Also makes #69 (docker/login-action **v3.7.0**) obsolete, since this jumps straight to v4.2.0 — please close #69.