### PR TITLE
feat(ci): bundle squashfs image instead of tar

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -24,19 +24,12 @@ jobs:
         with:
           release-type: node
 
-  build-and-publish:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      REGISTRY: ghcr.io
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Install ORAS
-        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -50,8 +43,37 @@ jobs:
       - name: Build
         run: npm run generate
 
+      - name: Install squashfs-tools
+        run: sudo apt-get install -y squashfs-tools
+
       - name: Archive build output
-        run: tar -czf spectra.tar.gz -C dist .
+        run: mksquashfs dist spectra.squashfs -comp zstd -noappend
+
+      - name: Verify squashfs
+        run: unsquashfs -s spectra.squashfs
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: spectra.squashfs
+          path: spectra.squashfs
+          retention-days: 1
+
+  publish:
+    needs: [release-please, build]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      REGISTRY: ghcr.io
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: spectra.squashfs
+
+      - name: Install ORAS
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
 
       - name: Login to registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -84,5 +106,5 @@ jobs:
             oras push "$TAG" \
               "${LABEL_ARGS[@]}" \
               --artifact-type application/vnd.spectra \
-              ./spectra.tar.gz:application/vnd.spectra.tar+gzip
+              ./spectra.squashfs:application/vnd.spectra.squashfs
           done <<<'${{ steps.meta.outputs.tags }}'


### PR DESCRIPTION
Switches the OCI layer from `spectra.tar.gz` (`application/vnd.spectra.tar+gzip`) to `spectra.squashfs` (`application/vnd.spectra.squashfs`) so aperture can serve it via a loop mount without unpacking.

Also splits the workflow into a `build` job (runs on every push, installs `squashfs-tools`, validates the image with `unsquashfs -s`) and a `publish` job (runs on release, downloads the pre-built artifact and pushes to GHCR).

Aperture changes (media type + mount logic) will follow in a separate PR.