### PR TITLE
chore: group renovate dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", ":automergePatch", ":automergeLinters"]
+  "extends": [
+    "config:best-practices",
+    ":automergePatch",
+    ":automergeLinters",
+    "group:allNonMajor"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "CI"
+    }
+  ]
 }


### PR DESCRIPTION
Groups Renovate updates to reduce PR noise.

**Before:** nearly every dependency update opens its own PR (e.g. #197, #198, #199).

**After:**
- `group:allNonMajor` collapses all non-major updates (npm, actions, etc.) into a single PR.
- A dedicated `github-actions` rule pulls all CI action updates (including majors) into one "CI" PR.
- App-dep majors stay as individual PRs since they need review.

Preserves existing `:automergePatch` and `:automergeLinters` behavior.