### PR TITLE
feat: add deno SSR export alongside static export

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -40,27 +40,32 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
+      - name: Build (static)
         run: npm run generate
+
+      - name: Build (deno SSR)
+        run: npm run build:deno
 
       - name: Install squashfs-tools
         run: sudo apt-get install -y squashfs-tools
 
-      - name: Archive build output
+      - name: Archive build outputs
         run: |
-          dist=$(realpath dist)
           repro_time=$(git log -1 --format=%ct)
-          mksquashfs "${dist}" spectra.squashfs \
-            -comp zstd -noappend \
+          squashfs_args=(-comp zstd -noappend \
             -mkfs-time "${repro_time}" -all-time "${repro_time}" -root-time "${repro_time}" \
-            -force-uid 0 -force-gid 0 \
-            -info
+            -force-uid 0 -force-gid 0 -info)
 
-      - name: Upload artifact
+          mksquashfs "$(realpath dist)" spectra-static.squashfs "${squashfs_args[@]}"
+          mksquashfs "$(realpath .output)" spectra-deno.squashfs "${squashfs_args[@]}"
+
+      - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: spectra.squashfs
-          path: spectra.squashfs
+          name: spectra-squashfs
+          path: |
+            spectra-static.squashfs
+            spectra-deno.squashfs
           retention-days: 1
 
   publish:
@@ -74,7 +79,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: spectra.squashfs
+          name: spectra-squashfs
 
       - name: Install ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
@@ -110,5 +115,6 @@ jobs:
             oras push "$TAG" \
               "${LABEL_ARGS[@]}" \
               --artifact-type application/vnd.spectra \
-              ./spectra.squashfs:application/vnd.spectra.squashfs
+              ./spectra-static.squashfs:application/vnd.spectra.squashfs \
+              ./spectra-deno.squashfs:application/vnd.spectra.deno.squashfs
           done <<<'${{ steps.meta.outputs.tags }}'

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,7 @@
 import { version } from "./package.json";
 
+const isDenoServer = process.env.NITRO_PRESET === "deno_server";
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: "2025-07-15",
@@ -45,7 +47,7 @@ export default defineNuxtConfig({
   nitro: {
     compressPublicAssets: true,
     prerender: {
-      crawlLinks: true,
+      crawlLinks: !isDenoServer,
       failOnError: false,
     },
     devProxy: {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "nuxt build",
+    "build:deno": "NITRO_PRESET=deno_server nuxt build",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",


### PR DESCRIPTION
Builds both a static pre-rendered SPA and a Deno SSR server from the
shared nuxt config. The static build keeps full crawl-link prerendering.
The Deno build (`build:deno`) uses the `deno-server` preset with pure SSR
and no prerendered routes.

The release OCI artifact now carries two squashfs blobs in one manifest.
Aperture selects the layer by media type based on device capability:

- `application/vnd.spectra.squashfs` (static, unchanged)
- `application/vnd.spectra.deno.squashfs` (new, SSR)

The Deno squashfs root holds the contents of `.output/` directly, so the
entrypoint is `server/index.mjs`. It is meant to be run through Aperture's
embedded deno_runtime with net, read, write and env permissions.