### PR TITLE
feat: implement authentication

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 CHANGELOG.md
 
 # Generated files
-openapi/openapi.json
-app/utils/api/generated.ts
+modules/aperture/openapi.json
+modules/aperture/runtime/generated.ts

--- a/app/layouts/auth.vue
+++ b/app/layouts/auth.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="min-h-screen flex flex-col items-center justify-center gap-8 p-4">
+    <div class="flex flex-col items-center gap-1 text-center">
+      <UIcon name="i-lucide-grid-3x3" class="size-10 text-primary" />
+      <h1 class="text-xl font-semibold">{{ $t("app.name") }}</h1>
+      <p class="text-muted text-sm">{{ $t("app.description") }}</p>
+    </div>
+    <div class="w-full max-w-sm">
+      <slot />
+    </div>
+  </div>
+</template>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
+import type { DropdownMenuItem } from "@nuxt/ui";
+
 const open = ref(false);
 const { t } = useI18n();
 const localePath = useLocalePath();
+const { user, logout } = useAuth();
 
 const closeSidebar = () => {
   open.value = false;
 };
+
+async function signOut() {
+  await logout();
+  await navigateTo(localePath("/login"));
+}
 
 const links = computed(() => [
   [
@@ -47,6 +55,23 @@ const groups = computed(() => [
     items: links.value.flat(),
   },
 ]);
+
+const userItems = computed<DropdownMenuItem[][]>(() => [
+  [
+    {
+      label: user.value?.username ?? user.value?.display_name ?? "",
+      avatar: { icon: "i-lucide-user" },
+      type: "label",
+    },
+  ],
+  [
+    {
+      label: t("auth.menu.signOut"),
+      icon: "i-lucide-log-out",
+      onSelect: signOut,
+    },
+  ],
+]);
 </script>
 
 <template>
@@ -77,6 +102,29 @@ const groups = computed(() => [
           tooltip
           class="mt-auto"
         />
+      </template>
+
+      <template #footer="{ collapsed }">
+        <UDropdownMenu
+          v-if="user"
+          :items="userItems"
+          :content="{ align: 'start' }"
+          :ui="{ content: 'w-56' }"
+          class="w-full"
+        >
+          <UButton
+            color="neutral"
+            variant="ghost"
+            class="w-full"
+            :class="collapsed ? 'justify-center' : 'justify-start'"
+            :block="!collapsed"
+          >
+            <UAvatar :icon="collapsed ? 'i-lucide-user' : undefined" size="2xs" />
+            <span v-if="!collapsed" class="truncate">
+              {{ user.username ?? user.display_name }}
+            </span>
+          </UButton>
+        </UDropdownMenu>
       </template>
     </UDashboardSidebar>
 

--- a/app/middleware/auth.global.ts
+++ b/app/middleware/auth.global.ts
@@ -1,0 +1,36 @@
+export default defineNuxtRouteMiddleware(async (to) => {
+  if (import.meta.server) {
+    return;
+  }
+
+  const { setupStatus, user, isAuthenticated, mustChangePassword, init } = useAuth();
+  const localePath = useLocalePath();
+
+  if (setupStatus.value === "unknown" && user.value === null) {
+    await init();
+  }
+
+  const name = String(to.name ?? "");
+  const isLogin = name.startsWith("login");
+  const isSetup = name.startsWith("setup");
+  const isChangePassword = name.startsWith("change-password");
+
+  if (setupStatus.value === "required" && !isSetup) {
+    return navigateTo(localePath("/setup"));
+  }
+
+  if (!isAuthenticated.value) {
+    if (isLogin || isSetup) {
+      return;
+    }
+    return navigateTo(localePath("/login"));
+  }
+
+  if (mustChangePassword.value && !isChangePassword) {
+    return navigateTo(localePath("/change-password"));
+  }
+
+  if ((isLogin || isSetup) && !mustChangePassword.value) {
+    return navigateTo(localePath("/"));
+  }
+});

--- a/app/pages/change-password.vue
+++ b/app/pages/change-password.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import type { FormSubmitEvent } from "@nuxt/ui";
+import { changePasswordSchema, type ChangePasswordValues } from "~/utils/auth";
+
+definePageMeta({ layout: "auth" });
+
+const { t } = useI18n();
+const localePath = useLocalePath();
+const { changePassword } = useAuth();
+
+const state = reactive({ currentPassword: "", newPassword: "", confirmPassword: "" });
+const errorMessage = ref<string | null>(null);
+const loading = ref(false);
+
+async function onSubmit(event: FormSubmitEvent<ChangePasswordValues>) {
+  errorMessage.value = null;
+  if (event.data.newPassword !== event.data.confirmPassword) {
+    errorMessage.value = t("auth.changePassword.passwordsMismatch");
+    return;
+  }
+  if (event.data.newPassword === event.data.currentPassword) {
+    errorMessage.value = t("auth.changePassword.passwordReuse");
+    return;
+  }
+  loading.value = true;
+  try {
+    await changePassword(event.data.currentPassword, event.data.newPassword);
+    await navigateTo(localePath("/"));
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 401) {
+      errorMessage.value = t("auth.changePassword.wrongCurrent");
+    } else {
+      errorMessage.value = t("auth.changePassword.failed");
+    }
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+
+<template>
+  <UPageCard variant="subtle">
+    <div class="flex flex-col gap-1 mb-4">
+      <h2 class="text-lg font-semibold">{{ $t("auth.changePassword.title") }}</h2>
+      <p class="text-muted text-sm">{{ $t("auth.changePassword.subtitle") }}</p>
+    </div>
+
+    <UAlert v-if="errorMessage" color="error" variant="subtle" :title="errorMessage" class="mb-4" />
+
+    <UForm
+      :schema="changePasswordSchema"
+      :state="state"
+      class="flex flex-col gap-4"
+      @submit="onSubmit"
+    >
+      <UFormField :label="$t('auth.changePassword.current')" name="currentPassword">
+        <UInput
+          v-model="state.currentPassword"
+          type="password"
+          autofocus
+          autocomplete="current-password"
+          class="w-full"
+        />
+      </UFormField>
+
+      <UFormField :label="$t('auth.changePassword.new')" name="newPassword">
+        <UInput
+          v-model="state.newPassword"
+          type="password"
+          autocomplete="new-password"
+          class="w-full"
+        />
+      </UFormField>
+
+      <UFormField :label="$t('auth.changePassword.confirm')" name="confirmPassword">
+        <UInput
+          v-model="state.confirmPassword"
+          type="password"
+          autocomplete="new-password"
+          class="w-full"
+        />
+      </UFormField>
+
+      <UButton type="submit" block :loading="loading" :label="$t('auth.changePassword.submit')" />
+    </UForm>
+  </UPageCard>
+</template>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import type { FormSubmitEvent } from "@nuxt/ui";
+import { loginSchema, type LoginValues } from "~/utils/auth";
+
+definePageMeta({ layout: "auth" });
+
+const { t } = useI18n();
+const localePath = useLocalePath();
+const { login } = useAuth();
+
+const state = reactive({ username: "", password: "" });
+const errorMessage = ref<string | null>(null);
+const loading = ref(false);
+
+async function onSubmit(event: FormSubmitEvent<LoginValues>) {
+  errorMessage.value = null;
+  loading.value = true;
+  try {
+    await login(event.data.username, event.data.password);
+    await navigateTo(localePath("/"));
+  } catch (err) {
+    errorMessage.value =
+      err instanceof ApiError && err.status === 429
+        ? t("auth.login.tooManyAttempts")
+        : t("auth.login.invalidCredentials");
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+
+<template>
+  <UPageCard variant="subtle">
+    <div class="flex flex-col gap-1 mb-4">
+      <h2 class="text-lg font-semibold">{{ $t("auth.login.title") }}</h2>
+      <p class="text-muted text-sm">{{ $t("auth.login.subtitle") }}</p>
+    </div>
+
+    <UAlert v-if="errorMessage" color="error" variant="subtle" :title="errorMessage" class="mb-4" />
+
+    <UForm :schema="loginSchema" :state="state" class="flex flex-col gap-4" @submit="onSubmit">
+      <UFormField :label="$t('auth.login.username')" name="username">
+        <UInput v-model="state.username" autofocus autocomplete="username" class="w-full" />
+      </UFormField>
+
+      <UFormField :label="$t('auth.login.password')" name="password">
+        <UInput
+          v-model="state.password"
+          type="password"
+          autocomplete="current-password"
+          class="w-full"
+        />
+      </UFormField>
+
+      <UButton type="submit" block :loading="loading" :label="$t('auth.login.submit')" />
+    </UForm>
+  </UPageCard>
+</template>

--- a/app/pages/setup.vue
+++ b/app/pages/setup.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import type { FormSubmitEvent } from "@nuxt/ui";
+import { setupSchema, type SetupValues } from "~/utils/auth";
+
+definePageMeta({ layout: "auth" });
+
+const { t } = useI18n();
+const localePath = useLocalePath();
+const { setupAdmin } = useAuth();
+
+const state = reactive({ username: "", password: "", confirmPassword: "" });
+const errorMessage = ref<string | null>(null);
+const loading = ref(false);
+
+async function onSubmit(event: FormSubmitEvent<SetupValues>) {
+  errorMessage.value = null;
+  if (event.data.password !== event.data.confirmPassword) {
+    errorMessage.value = t("auth.setup.passwordsMismatch");
+    return;
+  }
+  loading.value = true;
+  try {
+    await setupAdmin(event.data.username, event.data.password);
+    await navigateTo(localePath("/"));
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 409) {
+      await navigateTo(localePath("/login"));
+      return;
+    }
+    errorMessage.value = t("auth.setup.failed");
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+
+<template>
+  <UPageCard variant="subtle">
+    <div class="flex flex-col gap-1 mb-4">
+      <h2 class="text-lg font-semibold">{{ $t("auth.setup.title") }}</h2>
+      <p class="text-muted text-sm">{{ $t("auth.setup.subtitle") }}</p>
+    </div>
+
+    <UAlert v-if="errorMessage" color="error" variant="subtle" :title="errorMessage" class="mb-4" />
+
+    <UForm :schema="setupSchema" :state="state" class="flex flex-col gap-4" @submit="onSubmit">
+      <UFormField :label="$t('auth.setup.username')" name="username">
+        <UInput v-model="state.username" autofocus autocomplete="username" class="w-full" />
+      </UFormField>
+
+      <UFormField :label="$t('auth.setup.password')" name="password">
+        <UInput
+          v-model="state.password"
+          type="password"
+          autocomplete="new-password"
+          class="w-full"
+        />
+      </UFormField>
+
+      <UFormField :label="$t('auth.setup.confirmPassword')" name="confirmPassword">
+        <UInput
+          v-model="state.confirmPassword"
+          type="password"
+          autocomplete="new-password"
+          class="w-full"
+        />
+      </UFormField>
+
+      <UButton type="submit" block :loading="loading" :label="$t('auth.setup.submit')" />
+    </UForm>
+  </UPageCard>
+</template>

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -1,0 +1,29 @@
+import * as z from "zod/v4/mini";
+
+export const USERNAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+export const PASSWORD_MIN = 12;
+export const PASSWORD_MAX = 1024;
+
+const requiredString = z.string().check(z.minLength(1));
+const usernameField = z.string().check(z.minLength(1), z.maxLength(64), z.regex(USERNAME_PATTERN));
+const newPasswordField = z.string().check(z.minLength(PASSWORD_MIN), z.maxLength(PASSWORD_MAX));
+
+export type LoginValues = z.infer<typeof loginSchema>;
+export const loginSchema = z.object({
+  username: requiredString,
+  password: requiredString,
+});
+
+export type SetupValues = z.infer<typeof setupSchema>;
+export const setupSchema = z.object({
+  username: usernameField,
+  password: newPasswordField,
+  confirmPassword: requiredString,
+});
+
+export type ChangePasswordValues = z.infer<typeof changePasswordSchema>;
+export const changePasswordSchema = z.object({
+  currentPassword: requiredString,
+  newPassword: newPasswordField,
+  confirmPassword: requiredString,
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -25,7 +25,7 @@ function stubApi(mode: AuthMode) {
             actor_id: "2",
             display_name: "admin",
             username: "admin",
-            role: "admin",
+            roles: ["admin"],
             must_change_password: true,
           }),
         });

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+type AuthMode = "unauthenticated" | "setupRequired" | "mustChangePassword";
+
+function stubApi(mode: AuthMode) {
+  return async (route: import("@playwright/test").Route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: mode === "setupRequired" }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      if (mode === "mustChangePassword") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            actor_id: "2",
+            display_name: "admin",
+            username: "admin",
+            role: "admin",
+            must_change_password: true,
+          }),
+        });
+      } else {
+        await route.fulfill({ status: 401 });
+      }
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  };
+}
+
+test.describe("auth redirects", () => {
+  test("redirects to login when unauthenticated", async ({ page }) => {
+    await page.route("**/api/v1/**", stubApi("unauthenticated"));
+    await page.goto("/en/", { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(/\/en\/login$/);
+  });
+
+  test("redirects to setup when first-run setup is required", async ({ page }) => {
+    await page.route("**/api/v1/**", stubApi("setupRequired"));
+    await page.goto("/en/", { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(/\/en\/setup$/);
+  });
+
+  test("redirects to change-password when a password change is required", async ({ page }) => {
+    await page.route("**/api/v1/**", stubApi("mustChangePassword"));
+    await page.goto("/en/", { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(/\/en\/change-password$/);
+  });
+});

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -7,6 +7,42 @@
   "home": "Startseite",
   "go-to": "Gehe zu",
   "notifications": "Benachrichtigungen",
+  "auth": {
+    "menu": {
+      "signOut": "Abmelden"
+    },
+    "login": {
+      "title": "Anmelden",
+      "subtitle": "Gib deine Anmeldedaten ein, um fortzufahren.",
+      "username": "Benutzername",
+      "password": "Passwort",
+      "submit": "Anmelden",
+      "invalidCredentials": "Benutzername oder Passwort ungültig.",
+      "tooManyAttempts": "Zu viele Versuche. Versuche es später erneut."
+    },
+    "setup": {
+      "title": "Administratorkonto erstellen",
+      "subtitle": "Richte das erste Administratorkonto ein.",
+      "username": "Benutzername",
+      "password": "Passwort",
+      "confirmPassword": "Passwort bestätigen",
+      "submit": "Konto erstellen",
+      "failed": "Einrichtung fehlgeschlagen.",
+      "passwordsMismatch": "Passwörter stimmen nicht überein."
+    },
+    "changePassword": {
+      "title": "Passwort ändern",
+      "subtitle": "Wähle ein neues Passwort, bevor du fortfährst.",
+      "current": "Aktuelles Passwort",
+      "new": "Neues Passwort",
+      "confirm": "Neues Passwort bestätigen",
+      "submit": "Passwort ändern",
+      "wrongCurrent": "Aktuelles Passwort ist falsch.",
+      "failed": "Passwort konnte nicht geändert werden.",
+      "passwordsMismatch": "Passwörter stimmen nicht überein.",
+      "passwordReuse": "Das neue Passwort muss sich vom aktuellen unterscheiden."
+    }
+  },
   "settings": {
     "title": "Einstellungen",
     "description": "eCube-Präferenzen, Schwellenwerte und regionale Optionen anpassen.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -7,6 +7,42 @@
   "home": "Home",
   "go-to": "Go to",
   "notifications": "Notifications",
+  "auth": {
+    "menu": {
+      "signOut": "Sign out"
+    },
+    "login": {
+      "title": "Sign in",
+      "subtitle": "Enter your credentials to continue.",
+      "username": "Username",
+      "password": "Password",
+      "submit": "Sign in",
+      "invalidCredentials": "Invalid username or password.",
+      "tooManyAttempts": "Too many attempts. Try again later."
+    },
+    "setup": {
+      "title": "Create admin account",
+      "subtitle": "Set up the first administrator account.",
+      "username": "Username",
+      "password": "Password",
+      "confirmPassword": "Confirm password",
+      "submit": "Create account",
+      "failed": "Setup failed.",
+      "passwordsMismatch": "Passwords do not match."
+    },
+    "changePassword": {
+      "title": "Change password",
+      "subtitle": "Choose a new password before continuing.",
+      "current": "Current password",
+      "new": "New password",
+      "confirm": "Confirm new password",
+      "submit": "Change password",
+      "wrongCurrent": "Current password is incorrect.",
+      "failed": "Failed to change password.",
+      "passwordsMismatch": "Passwords do not match.",
+      "passwordReuse": "New password must differ from the current password."
+    }
+  },
   "settings": {
     "title": "Settings",
     "description": "Adjust eCube preferences, thresholds, and regional options.",

--- a/modules/aperture/module.ts
+++ b/modules/aperture/module.ts
@@ -1,4 +1,4 @@
-import { defineNuxtModule, createResolver, addImports, addImportsDir } from "@nuxt/kit";
+import { defineNuxtModule, createResolver, addImports, addImportsDir, addPlugin } from "@nuxt/kit";
 
 export default defineNuxtModule({
   meta: {
@@ -7,7 +7,12 @@ export default defineNuxtModule({
   setup() {
     const { resolve } = createResolver(import.meta.url);
 
-    addImports([{ name: "apertureApi", from: resolve("./runtime/client") }]);
+    addImports([
+      { name: "apertureApi", from: resolve("./runtime/client") },
+      { name: "ApiError", from: resolve("./runtime/client") },
+      { name: "setUnauthorizedHandler", from: resolve("./runtime/client") },
+    ]);
     addImportsDir(resolve("./runtime/composables"));
+    addPlugin(resolve("./runtime/plugins/auth.client.ts"));
   },
 });

--- a/modules/aperture/openapi.json
+++ b/modules/aperture/openapi.json
@@ -502,7 +502,9 @@
             "description": "Invalid credentials"
           }
         },
-        "security": [{}]
+        "security": [
+          {}
+        ]
       }
     },
     "/api/v1/auth/logout": {
@@ -512,6 +514,24 @@
         "responses": {
           "204": {
             "description": "Logged out"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "summary": "Returns the authenticated caller's identity and role.",
+        "operationId": "getCurrentUser",
+        "responses": {
+          "200": {
+            "description": "Current caller",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentUserResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -545,7 +565,9 @@
             "description": "Setup already complete"
           }
         },
-        "security": [{}]
+        "security": [
+          {}
+        ]
       }
     },
     "/api/v1/auth/setup-status": {
@@ -564,7 +586,9 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          {}
+        ]
       }
     },
     "/api/v1/logs": {
@@ -1451,13 +1475,20 @@
       },
       "ApiKeyResponse": {
         "type": "object",
-        "required": ["id", "name", "prefix"],
+        "required": [
+          "id",
+          "name",
+          "prefix"
+        ],
         "properties": {
           "id": {
             "type": "string"
           },
           "last_used_at": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "name": {
             "type": "string"
@@ -1475,7 +1506,14 @@
       "ArtifactSummaryResponse": {
         "type": "object",
         "description": "A distinct artifact key with its newest version, for `GET\n/api/v1/artifacts`.",
-        "required": ["key", "version_count", "source", "digest", "size_bytes", "downloaded_at"],
+        "required": [
+          "key",
+          "version_count",
+          "source",
+          "digest",
+          "size_bytes",
+          "downloaded_at"
+        ],
         "properties": {
           "digest": {
             "$ref": "#/components/schemas/Digest",
@@ -1501,7 +1539,10 @@
             "description": "Where the newest version came from."
           },
           "version": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Human-readable version of the newest version, if known."
           },
           "version_count": {
@@ -1515,7 +1556,13 @@
       "ArtifactVersionResponse": {
         "type": "object",
         "description": "One stored version of an artifact.",
-        "required": ["key", "digest", "source", "size_bytes", "downloaded_at"],
+        "required": [
+          "key",
+          "digest",
+          "source",
+          "size_bytes",
+          "downloaded_at"
+        ],
         "properties": {
           "digest": {
             "$ref": "#/components/schemas/Digest",
@@ -1552,12 +1599,18 @@
             "description": "Where this version came from."
           },
           "verified_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "description": "When this version was last verified, if ever."
           },
           "version": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Human-readable version, if known."
           }
         }
@@ -1565,7 +1618,13 @@
       "BootResponse": {
         "type": "object",
         "description": "One boot session observed in the log store, returned by\n`GET /api/v1/logs/boots`.",
-        "required": ["boot_id", "first_seen", "last_seen", "event_count", "is_current"],
+        "required": [
+          "boot_id",
+          "first_seen",
+          "last_seen",
+          "event_count",
+          "is_current"
+        ],
         "properties": {
           "boot_id": {
             "type": "string",
@@ -1596,7 +1655,10 @@
       },
       "ChangePasswordRequest": {
         "type": "object",
-        "required": ["current_password", "new_password"],
+        "required": [
+          "current_password",
+          "new_password"
+        ],
         "properties": {
           "current_password": {
             "$ref": "#/components/schemas/Password"
@@ -1608,7 +1670,9 @@
       },
       "CreateApiKeyRequest": {
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -1628,7 +1692,12 @@
       },
       "CreateApiKeyResponse": {
         "type": "object",
-        "required": ["id", "name", "prefix", "key"],
+        "required": [
+          "id",
+          "name",
+          "prefix",
+          "key"
+        ],
         "properties": {
           "id": {
             "type": "string"
@@ -1649,27 +1718,37 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["kind", "input"],
-            "properties": {
-              "input": {
-                "$ref": "#/components/schemas/DownloadInput"
-              },
-              "kind": {
-                "type": "string",
-                "enum": ["download"]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": ["kind", "input"],
+            "required": [
+              "kind",
+              "input"
+            ],
             "properties": {
               "input": {
                 "$ref": "#/components/schemas/RotateCertificateInput"
               },
               "kind": {
                 "type": "string",
-                "enum": ["rotate-certificate"]
+                "enum": [
+                  "rotate-certificate"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "kind",
+              "input"
+            ],
+            "properties": {
+              "input": {
+                "$ref": "#/components/schemas/DownloadInput"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "download"
+                ]
               }
             }
           }
@@ -1681,7 +1760,10 @@
       "CreateTaskRequest": {
         "type": "object",
         "description": "Body for `POST /api/v1/tasks`.",
-        "required": ["kind", "input"],
+        "required": [
+          "kind",
+          "input"
+        ],
         "properties": {
           "input": {
             "description": "The task input, matching the kind's input schema."
@@ -1695,7 +1777,11 @@
       "CreateTaskScheduleRequest": {
         "type": "object",
         "description": "Body for `POST /api/v1/task-schedules`.",
-        "required": ["kind", "input", "interval"],
+        "required": [
+          "kind",
+          "input",
+          "interval"
+        ],
         "properties": {
           "input": {},
           "interval": {
@@ -1708,7 +1794,10 @@
       },
       "CreateUserRequest": {
         "type": "object",
-        "required": ["username", "password"],
+        "required": [
+          "username",
+          "password"
+        ],
         "properties": {
           "password": {
             "$ref": "#/components/schemas/Password"
@@ -1728,6 +1817,41 @@
           }
         }
       },
+      "CurrentUserResponse": {
+        "type": "object",
+        "required": [
+          "actor_id",
+          "display_name",
+          "must_change_password"
+        ],
+        "properties": {
+          "actor_id": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "must_change_password": {
+            "type": "boolean"
+          },
+          "role": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Role"
+              }
+            ]
+          },
+          "username": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
       "Digest": {
         "type": "string",
         "description": "Content digest, e.g. `sha256:hex`."
@@ -1735,7 +1859,10 @@
       "DownloadInput": {
         "type": "object",
         "description": "Input for a download task: what to fetch and where from.",
-        "required": ["key", "source"],
+        "required": [
+          "key",
+          "source"
+        ],
         "properties": {
           "key": {
             "$ref": "#/components/schemas/ArtifactKey",
@@ -1750,7 +1877,10 @@
       "DownloadOutput": {
         "type": "object",
         "description": "Output of a download task: the stored version that resulted.",
-        "required": ["digest", "size_bytes"],
+        "required": [
+          "digest",
+          "size_bytes"
+        ],
         "properties": {
           "digest": {
             "$ref": "#/components/schemas/Digest",
@@ -1763,7 +1893,10 @@
             "minimum": 0
           },
           "version": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Human-readable version, if known."
           }
         }
@@ -1773,7 +1906,11 @@
           {
             "type": "object",
             "description": "A layer of an OCI image.",
-            "required": ["reference", "media_type", "type"],
+            "required": [
+              "reference",
+              "media_type",
+              "type"
+            ],
             "properties": {
               "media_type": {
                 "$ref": "#/components/schemas/MediaType",
@@ -1785,7 +1922,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["oci"]
+                "enum": [
+                  "oci"
+                ]
               }
             }
           }
@@ -1810,12 +1949,25 @@
       "LevelResponse": {
         "type": "string",
         "description": "Severity level of a log event or span.",
-        "enum": ["trace", "debug", "info", "warn", "error"]
+        "enum": [
+          "trace",
+          "debug",
+          "info",
+          "warn",
+          "error"
+        ]
       },
       "LogEventResponse": {
         "type": "object",
         "description": "A single log event, returned by `GET /api/v1/logs`.",
-        "required": ["id", "level", "target", "timestamp", "boot_id", "fields"],
+        "required": [
+          "id",
+          "level",
+          "target",
+          "timestamp",
+          "boot_id",
+          "fields"
+        ],
         "properties": {
           "boot_id": {
             "type": "string",
@@ -1831,7 +1983,10 @@
             }
           },
           "file": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Source file, if available."
           },
           "id": {
@@ -1843,13 +1998,19 @@
             "description": "Severity level."
           },
           "line": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int32",
             "description": "Source line, if available.",
             "minimum": 0
           },
           "message": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Human-readable message, if any."
           },
           "span_id": {
@@ -1881,7 +2042,9 @@
           },
           {
             "type": "object",
-            "required": ["events"],
+            "required": [
+              "events"
+            ],
             "properties": {
               "events": {
                 "type": "array",
@@ -1898,10 +2061,20 @@
       "LogSpanResponse": {
         "type": "object",
         "description": "A tracing span, returned by `GET /api/v1/logs/spans`.",
-        "required": ["id", "name", "level", "target", "started_at", "fields"],
+        "required": [
+          "id",
+          "name",
+          "level",
+          "target",
+          "started_at",
+          "fields"
+        ],
         "properties": {
           "ended_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "description": "When the span ended, if it did."
           },
@@ -1914,7 +2087,10 @@
             }
           },
           "file": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Source file, if available."
           },
           "id": {
@@ -1926,7 +2102,10 @@
             "description": "Severity level."
           },
           "line": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int32",
             "description": "Source line, if available.",
             "minimum": 0
@@ -1959,7 +2138,10 @@
       },
       "LoginRequest": {
         "type": "object",
-        "required": ["username", "password"],
+        "required": [
+          "username",
+          "password"
+        ],
         "properties": {
           "password": {
             "$ref": "#/components/schemas/Password"
@@ -1971,7 +2153,9 @@
       },
       "LoginResponse": {
         "type": "object",
-        "required": ["must_change_password"],
+        "required": [
+          "must_change_password"
+        ],
         "properties": {
           "must_change_password": {
             "type": "boolean"
@@ -1985,12 +2169,17 @@
       "OrderParam": {
         "type": "string",
         "description": "Sort direction shared by list endpoints.",
-        "enum": ["asc", "desc"]
+        "enum": [
+          "asc",
+          "desc"
+        ]
       },
       "Page_ArtifactSummaryResponse": {
         "type": "object",
         "description": "A page of results plus the cursors for the neighbouring pages.",
-        "required": ["items"],
+        "required": [
+          "items"
+        ],
         "properties": {
           "items": {
             "type": "array",
@@ -2030,7 +2219,10 @@
                   "description": "Where the newest version came from."
                 },
                 "version": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Human-readable version of the newest version, if known."
                 },
                 "version_count": {
@@ -2044,11 +2236,17 @@
             "description": "The rows in this page."
           },
           "next_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the next page. Null at the end."
           },
           "prev_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the previous page. Null at the start."
           }
         }
@@ -2056,14 +2254,22 @@
       "Page_ArtifactVersionResponse": {
         "type": "object",
         "description": "A page of results plus the cursors for the neighbouring pages.",
-        "required": ["items"],
+        "required": [
+          "items"
+        ],
         "properties": {
           "items": {
             "type": "array",
             "items": {
               "type": "object",
               "description": "One stored version of an artifact.",
-              "required": ["key", "digest", "source", "size_bytes", "downloaded_at"],
+              "required": [
+                "key",
+                "digest",
+                "source",
+                "size_bytes",
+                "downloaded_at"
+              ],
               "properties": {
                 "digest": {
                   "$ref": "#/components/schemas/Digest",
@@ -2100,12 +2306,18 @@
                   "description": "Where this version came from."
                 },
                 "verified_at": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "format": "date-time",
                   "description": "When this version was last verified, if ever."
                 },
                 "version": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Human-readable version, if known."
                 }
               }
@@ -2113,11 +2325,17 @@
             "description": "The rows in this page."
           },
           "next_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the next page. Null at the end."
           },
           "prev_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the previous page. Null at the start."
           }
         }
@@ -2125,14 +2343,23 @@
       "Page_LogEventResponse": {
         "type": "object",
         "description": "A page of results plus the cursors for the neighbouring pages.",
-        "required": ["items"],
+        "required": [
+          "items"
+        ],
         "properties": {
           "items": {
             "type": "array",
             "items": {
               "type": "object",
               "description": "A single log event, returned by `GET /api/v1/logs`.",
-              "required": ["id", "level", "target", "timestamp", "boot_id", "fields"],
+              "required": [
+                "id",
+                "level",
+                "target",
+                "timestamp",
+                "boot_id",
+                "fields"
+              ],
               "properties": {
                 "boot_id": {
                   "type": "string",
@@ -2148,7 +2375,10 @@
                   }
                 },
                 "file": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Source file, if available."
                 },
                 "id": {
@@ -2160,13 +2390,19 @@
                   "description": "Severity level."
                 },
                 "line": {
-                  "type": ["integer", "null"],
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
                   "format": "int32",
                   "description": "Source line, if available.",
                   "minimum": 0
                 },
                 "message": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Human-readable message, if any."
                 },
                 "span_id": {
@@ -2194,11 +2430,17 @@
             "description": "The rows in this page."
           },
           "next_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the next page. Null at the end."
           },
           "prev_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the previous page. Null at the start."
           }
         }
@@ -2206,17 +2448,29 @@
       "Page_LogSpanResponse": {
         "type": "object",
         "description": "A page of results plus the cursors for the neighbouring pages.",
-        "required": ["items"],
+        "required": [
+          "items"
+        ],
         "properties": {
           "items": {
             "type": "array",
             "items": {
               "type": "object",
               "description": "A tracing span, returned by `GET /api/v1/logs/spans`.",
-              "required": ["id", "name", "level", "target", "started_at", "fields"],
+              "required": [
+                "id",
+                "name",
+                "level",
+                "target",
+                "started_at",
+                "fields"
+              ],
               "properties": {
                 "ended_at": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "format": "date-time",
                   "description": "When the span ended, if it did."
                 },
@@ -2229,7 +2483,10 @@
                   }
                 },
                 "file": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Source file, if available."
                 },
                 "id": {
@@ -2241,7 +2498,10 @@
                   "description": "Severity level."
                 },
                 "line": {
-                  "type": ["integer", "null"],
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
                   "format": "int32",
                   "description": "Source line, if available.",
                   "minimum": 0
@@ -2275,11 +2535,17 @@
             "description": "The rows in this page."
           },
           "next_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the next page. Null at the end."
           },
           "prev_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the previous page. Null at the start."
           }
         }
@@ -2287,14 +2553,22 @@
       "Page_TaskResponse": {
         "type": "object",
         "description": "A page of results plus the cursors for the neighbouring pages.",
-        "required": ["items"],
+        "required": [
+          "items"
+        ],
         "properties": {
           "items": {
             "type": "array",
             "items": {
               "type": "object",
               "description": "One task invocation, returned by the task endpoints.",
-              "required": ["id", "kind", "status", "input", "created_at"],
+              "required": [
+                "id",
+                "kind",
+                "status",
+                "input",
+                "created_at"
+              ],
               "properties": {
                 "created_at": {
                   "type": "string",
@@ -2302,11 +2576,17 @@
                   "description": "When the invocation was recorded."
                 },
                 "error": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Failure detail, if any."
                 },
                 "finished_at": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "format": "date-time",
                   "description": "When it finished, if it did."
                 },
@@ -2347,7 +2627,10 @@
                   ]
                 },
                 "started_at": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "format": "date-time",
                   "description": "When it started running, if it did."
                 },
@@ -2360,11 +2643,17 @@
             "description": "The rows in this page."
           },
           "next_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the next page. Null at the end."
           },
           "prev_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the previous page. Null at the start."
           }
         }
@@ -2372,7 +2661,9 @@
       "Page_TaskScheduleResponse": {
         "type": "object",
         "description": "A page of results plus the cursors for the neighbouring pages.",
-        "required": ["items"],
+        "required": [
+          "items"
+        ],
         "properties": {
           "items": {
             "type": "array",
@@ -2406,7 +2697,10 @@
                   "type": "string"
                 },
                 "last_run_at": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "format": "date-time"
                 },
                 "last_task_id": {
@@ -2428,11 +2722,17 @@
             "description": "The rows in this page."
           },
           "next_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the next page. Null at the end."
           },
           "prev_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Cursor to pass as `?cursor=` for the previous page. Null at the start."
           }
         }
@@ -2444,7 +2744,10 @@
       "ProgressMessageResponse": {
         "type": "object",
         "description": "A localizable progress message: a translation key and its arguments.",
-        "required": ["key", "args"],
+        "required": [
+          "key",
+          "args"
+        ],
         "properties": {
           "args": {
             "type": "object",
@@ -2467,7 +2770,10 @@
         "description": "Live progress of a running task.",
         "properties": {
           "done": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int64",
             "description": "Units of work completed so far.",
             "minimum": 0
@@ -2484,7 +2790,10 @@
             ]
           },
           "total": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int64",
             "description": "Total units of work expected, if known.",
             "minimum": 0
@@ -2498,7 +2807,11 @@
       "Role": {
         "type": "string",
         "description": "A built-in role. Stored as its lowercase name in casbin grouping rules.",
-        "enum": ["admin", "operator", "viewer"]
+        "enum": [
+          "admin",
+          "operator",
+          "viewer"
+        ]
       },
       "RotateCertificateInput": {
         "type": "object",
@@ -2506,7 +2819,9 @@
       },
       "RotateCertificateOutput": {
         "type": "object",
-        "required": ["rotated"],
+        "required": [
+          "rotated"
+        ],
         "properties": {
           "rotated": {
             "type": "boolean",
@@ -2516,7 +2831,10 @@
       },
       "SetupRequest": {
         "type": "object",
-        "required": ["username", "password"],
+        "required": [
+          "username",
+          "password"
+        ],
         "properties": {
           "password": {
             "$ref": "#/components/schemas/Password"
@@ -2528,7 +2846,9 @@
       },
       "SetupStatusResponse": {
         "type": "object",
-        "required": ["setup_required"],
+        "required": [
+          "setup_required"
+        ],
         "properties": {
           "setup_required": {
             "type": "boolean"
@@ -2542,7 +2862,13 @@
       "TaskDefinitionResponse": {
         "type": "object",
         "description": "A registered task kind, with its capabilities and JSON Schemas.",
-        "required": ["kind", "cancellable", "resumable", "input_schema", "output_schema"],
+        "required": [
+          "kind",
+          "cancellable",
+          "resumable",
+          "input_schema",
+          "output_schema"
+        ],
         "properties": {
           "cancellable": {
             "type": "boolean",
@@ -2571,7 +2897,13 @@
       "TaskResponse": {
         "type": "object",
         "description": "One task invocation, returned by the task endpoints.",
-        "required": ["id", "kind", "status", "input", "created_at"],
+        "required": [
+          "id",
+          "kind",
+          "status",
+          "input",
+          "created_at"
+        ],
         "properties": {
           "created_at": {
             "type": "string",
@@ -2579,11 +2911,17 @@
             "description": "When the invocation was recorded."
           },
           "error": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Failure detail, if any."
           },
           "finished_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "description": "When it finished, if it did."
           },
@@ -2624,7 +2962,10 @@
             ]
           },
           "started_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "description": "When it started running, if it did."
           },
@@ -2640,7 +2981,15 @@
       },
       "TaskScheduleResponse": {
         "type": "object",
-        "required": ["id", "kind", "input", "interval", "next_run_at", "enabled", "created_at"],
+        "required": [
+          "id",
+          "kind",
+          "input",
+          "interval",
+          "next_run_at",
+          "enabled",
+          "created_at"
+        ],
         "properties": {
           "created_at": {
             "type": "string",
@@ -2660,7 +3009,10 @@
             "type": "string"
           },
           "last_run_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "last_task_id": {
@@ -2696,14 +3048,24 @@
       "TaskStatusResponse": {
         "type": "string",
         "description": "Lifecycle state of a task invocation.",
-        "enum": ["pending", "running", "succeeded", "failed", "cancelled", "interrupted"]
+        "enum": [
+          "pending",
+          "running",
+          "succeeded",
+          "failed",
+          "cancelled",
+          "interrupted"
+        ]
       },
       "UpdateTaskScheduleRequest": {
         "type": "object",
         "description": "Body for `PATCH /api/v1/task-schedules/{id}`.",
         "properties": {
           "enabled": {
-            "type": ["boolean", "null"]
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "interval": {
             "oneOf": [
@@ -2723,7 +3085,12 @@
       },
       "UserResponse": {
         "type": "object",
-        "required": ["id", "actor_id", "username", "must_change_password"],
+        "required": [
+          "id",
+          "actor_id",
+          "username",
+          "must_change_password"
+        ],
         "properties": {
           "actor_id": {
             "type": "string"
@@ -2746,7 +3113,10 @@
       "VersionResponse": {
         "type": "object",
         "description": "Version information returned by `GET /api/v1/version`.",
-        "required": ["aperture", "boot_id"],
+        "required": [
+          "aperture",
+          "boot_id"
+        ],
         "properties": {
           "aperture": {
             "type": "string",
@@ -2762,7 +3132,10 @@
       "VersionSortParam": {
         "type": "string",
         "description": "Field a version listing is sorted by.",
-        "enum": ["downloaded_at", "size_bytes"]
+        "enum": [
+          "downloaded_at",
+          "size_bytes"
+        ]
       }
     },
     "securitySchemes": {

--- a/modules/aperture/openapi.json
+++ b/modules/aperture/openapi.json
@@ -1469,6 +1469,10 @@
   },
   "components": {
     "schemas": {
+      "ActorId": {
+        "type": "string",
+        "description": "Primary key of a row in the `actors` table.\n\nUsed wherever an actor is referenced: `users.actor_id`,\n`sessions.actor_id`, `api_keys.actor_id`, `tasks.initiator_id`."
+      },
       "ApiKeyId": {
         "type": "string",
         "description": "Primary key of a row in the `api_keys` table."
@@ -1482,13 +1486,14 @@
         ],
         "properties": {
           "id": {
-            "type": "string"
+            "$ref": "#/components/schemas/ApiKeyId"
           },
           "last_used_at": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "format": "date-time"
           },
           "name": {
             "type": "string"
@@ -1700,7 +1705,7 @@
         ],
         "properties": {
           "id": {
-            "type": "string"
+            "$ref": "#/components/schemas/ApiKeyId"
           },
           "key": {
             "$ref": "#/components/schemas/RawApiKey",
@@ -1822,11 +1827,12 @@
         "required": [
           "actor_id",
           "display_name",
+          "roles",
           "must_change_password"
         ],
         "properties": {
           "actor_id": {
-            "type": "string"
+            "$ref": "#/components/schemas/ActorId"
           },
           "display_name": {
             "type": "string"
@@ -1834,15 +1840,11 @@
           "must_change_password": {
             "type": "boolean"
           },
-          "role": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/Role"
-              }
-            ]
+          "roles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Role"
+            }
           },
           "username": {
             "type": [
@@ -3093,10 +3095,10 @@
         ],
         "properties": {
           "actor_id": {
-            "type": "string"
+            "$ref": "#/components/schemas/ActorId"
           },
           "id": {
-            "type": "string"
+            "$ref": "#/components/schemas/UserId"
           },
           "must_change_password": {
             "type": "boolean"

--- a/modules/aperture/runtime/client.ts
+++ b/modules/aperture/runtime/client.ts
@@ -3,9 +3,13 @@ import type { paths } from "./generated";
 import type {
   BootList,
   BootResponse,
+  ChangePasswordBody,
+  CurrentUser,
   ListLogSpansParams,
   ListLogTargetsParams,
   ListLogsParams,
+  LoginBody,
+  LoginResponse,
   LogEvent,
   LogEventPage,
   LogSpan,
@@ -15,6 +19,8 @@ import type {
   RawLogEvent,
   RawLogSpan,
   RawLogSpanDetail,
+  SetupBody,
+  SetupStatus,
   VersionResponse,
 } from "./types";
 
@@ -22,11 +28,56 @@ const client = createClient<paths>({
   querySerializer: { array: { style: "form", explode: false } },
 });
 
-function unwrap<T>(res: { data?: T; error?: unknown }): T {
+export class ApiError extends Error {
+  readonly status: number;
+  constructor(status: number, message?: string) {
+    super(message ?? `request failed with status ${status}`);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+const AUTH_ENDPOINTS = new Set([
+  "/api/v1/auth/me",
+  "/api/v1/auth/login",
+  "/api/v1/auth/change-password",
+]);
+
+let unauthorizedHandler: (() => void) | null = null;
+
+client.use({
+  onResponse({ request, response }) {
+    if (response.status !== 401 || !unauthorizedHandler) {
+      return;
+    }
+    let pathname: string;
+    try {
+      pathname = new URL(request.url).pathname;
+    } catch {
+      return;
+    }
+    if (AUTH_ENDPOINTS.has(pathname)) {
+      return;
+    }
+    unauthorizedHandler();
+  },
+});
+
+export function setUnauthorizedHandler(fn: (() => void) | null): void {
+  unauthorizedHandler = fn;
+}
+
+function unwrap<T>(res: { data?: T; error?: unknown; response: Response }): T {
   if (res.data === undefined) {
-    throw res.error ?? new Error("aperture returned an empty response");
+    throw new ApiError(res.response.status);
   }
   return res.data;
+}
+
+function unwrapVoid(res: { data?: unknown; error?: unknown; response: Response }): void {
+  if (res.data === undefined && !res.response.ok) {
+    throw new ApiError(res.response.status);
+  }
 }
 
 function toLogEvent(e: RawLogEvent): LogEvent {
@@ -82,4 +133,23 @@ export const apertureApi = {
     toLogSpanDetail(
       unwrap(await client.GET("/api/v1/logs/spans/{id}", { params: { path: { id } } })),
     ),
+
+  getMe: async (): Promise<CurrentUser> => unwrap(await client.GET("/api/v1/auth/me")),
+
+  getSetupStatus: async (): Promise<SetupStatus> =>
+    unwrap(await client.GET("/api/v1/auth/setup-status")),
+
+  login: async (body: LoginBody): Promise<LoginResponse> =>
+    unwrap(await client.POST("/api/v1/auth/login", { body })),
+
+  logout: async (): Promise<void> => {
+    unwrapVoid(await client.POST("/api/v1/auth/logout"));
+  },
+
+  setup: async (body: SetupBody): Promise<LoginResponse> =>
+    unwrap(await client.POST("/api/v1/auth/setup", { body })),
+
+  changePassword: async (body: ChangePasswordBody): Promise<void> => {
+    unwrapVoid(await client.POST("/api/v1/auth/change-password", { body }));
+  },
 };

--- a/modules/aperture/runtime/composables/useAuth.ts
+++ b/modules/aperture/runtime/composables/useAuth.ts
@@ -1,0 +1,89 @@
+import { computed } from "vue";
+import { apertureApi } from "../client";
+import type { CurrentUser } from "../types";
+
+export type SetupStatus = "unknown" | "required" | "done";
+
+export function useAuth() {
+  const user = useState<CurrentUser | null>("auth:user", () => null);
+  const setupStatus = useState<SetupStatus>("auth:setup-status", () => "unknown");
+
+  const isAuthenticated = computed(() => user.value !== null);
+  const mustChangePassword = computed(() => user.value?.must_change_password ?? false);
+  const isAdmin = computed(() => user.value?.role === "admin");
+
+  async function fetchMe(): Promise<void> {
+    try {
+      user.value = await apertureApi.getMe();
+    } catch (err) {
+      user.value = null;
+      if (err instanceof ApiError && err.status !== 401) {
+        throw err;
+      }
+    }
+  }
+
+  async function fetchSetupStatus(): Promise<void> {
+    const data = await apertureApi.getSetupStatus();
+    setupStatus.value = data.setup_required ? "required" : "done";
+  }
+
+  async function init(): Promise<void> {
+    try {
+      await fetchSetupStatus();
+    } catch {
+      return;
+    }
+    if (setupStatus.value === "required") {
+      user.value = null;
+      return;
+    }
+    try {
+      await fetchMe();
+    } catch {
+      // Leave user state as-is on unexpected errors.
+    }
+  }
+
+  async function login(username: string, password: string): Promise<void> {
+    await apertureApi.login({ username, password });
+    await fetchMe();
+  }
+
+  async function logout(): Promise<void> {
+    try {
+      await apertureApi.logout();
+    } finally {
+      user.value = null;
+    }
+  }
+
+  async function setupAdmin(username: string, password: string): Promise<void> {
+    await apertureApi.setup({ username, password });
+    setupStatus.value = "done";
+    await fetchMe();
+  }
+
+  async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
+    await apertureApi.changePassword({
+      current_password: currentPassword,
+      new_password: newPassword,
+    });
+    await fetchMe();
+  }
+
+  return {
+    user,
+    setupStatus,
+    isAuthenticated,
+    mustChangePassword,
+    isAdmin,
+    fetchMe,
+    fetchSetupStatus,
+    init,
+    login,
+    logout,
+    setupAdmin,
+    changePassword,
+  };
+}

--- a/modules/aperture/runtime/composables/useAuth.ts
+++ b/modules/aperture/runtime/composables/useAuth.ts
@@ -10,7 +10,7 @@ export function useAuth() {
 
   const isAuthenticated = computed(() => user.value !== null);
   const mustChangePassword = computed(() => user.value?.must_change_password ?? false);
-  const isAdmin = computed(() => user.value?.role === "admin");
+  const isAdmin = computed(() => user.value?.roles.includes("admin") ?? false);
 
   async function fetchMe(): Promise<void> {
     try {

--- a/modules/aperture/runtime/generated.ts
+++ b/modules/aperture/runtime/generated.ts
@@ -4,2205 +4,2238 @@
  */
 
 export interface paths {
-  "/api/v1/api-keys": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/api-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lists API keys for the authenticated actor. */
+        get: operations["listApiKeys"];
+        put?: never;
+        /** Creates a new API key for the authenticated actor. */
+        post: operations["createApiKey"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Lists API keys for the authenticated actor. */
-    get: operations["listApiKeys"];
-    put?: never;
-    /** Creates a new API key for the authenticated actor. */
-    post: operations["createApiKey"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/api-keys/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/api-keys/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Deletes an API key. */
+        delete: operations["deleteApiKey"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Deletes an API key. */
-    delete: operations["deleteApiKey"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/artifacts": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/artifacts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lists stored artifact keys, each with its newest version. */
+        get: operations["listArtifacts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Lists stored artifact keys, each with its newest version. */
-    get: operations["listArtifacts"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/artifacts/{key}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/artifacts/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns one artifact key with its newest version. */
+        get: operations["getArtifact"];
+        /**
+         * Uploads a new artifact version.
+         * @description The request body is stored as a content-addressed blob. Subsequent uploads
+         *     of identical bytes do not replace the prior version. Instead, a new
+         *     `(key, digest)` row is recorded when the digest differs. This matches the
+         *     content-addressed storage model but is not a strict RFC 9110 PUT (which
+         *     would replace prior state). Treat this endpoint as "store these bytes under
+         *     this key" rather than "set this key to these bytes".
+         */
+        put: operations["uploadArtifact"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Returns one artifact key with its newest version. */
-    get: operations["getArtifact"];
-    /**
-     * Uploads a new artifact version.
-     * @description The request body is stored as a content-addressed blob. Subsequent uploads
-     *     of identical bytes do not replace the prior version. Instead, a new
-     *     `(key, digest)` row is recorded when the digest differs. This matches the
-     *     content-addressed storage model but is not a strict RFC 9110 PUT (which
-     *     would replace prior state). Treat this endpoint as "store these bytes under
-     *     this key" rather than "set this key to these bytes".
-     */
-    put: operations["uploadArtifact"];
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/artifacts/{key}/versions": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/artifacts/{key}/versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lists the stored versions of an artifact. */
+        get: operations["listArtifactVersions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Lists the stored versions of an artifact. */
-    get: operations["listArtifactVersions"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/artifacts/{key}/versions/{digest}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/artifacts/{key}/versions/{digest}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns one stored version. */
+        get: operations["getArtifactVersion"];
+        put?: never;
+        post?: never;
+        /** Evicts one stored version and its blob, if no other version needs it. */
+        delete: operations["deleteArtifactVersion"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Returns one stored version. */
-    get: operations["getArtifactVersion"];
-    put?: never;
-    post?: never;
-    /** Evicts one stored version and its blob, if no other version needs it. */
-    delete: operations["deleteArtifactVersion"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/artifacts/{key}/versions/{digest}/blob": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/artifacts/{key}/versions/{digest}/blob": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Downloads the blob content of one stored version. */
+        get: operations["downloadArtifactBlob"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Downloads the blob content of one stored version. */
-    get: operations["downloadArtifactBlob"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/auth/change-password": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/auth/change-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Changes the password for the authenticated user. */
+        post: operations["changePassword"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Changes the password for the authenticated user. */
-    post: operations["changePassword"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/auth/login": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Authenticates a user and creates a session. */
+        post: operations["login"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Authenticates a user and creates a session. */
-    post: operations["login"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/auth/logout": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Destroys the current session. */
+        post: operations["logout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Destroys the current session. */
-    post: operations["logout"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/auth/setup": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns the authenticated caller's identity and role. */
+        get: operations["getCurrentUser"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Creates the initial admin user. Only available when no users exist. */
-    post: operations["setup"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/auth/setup-status": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/auth/setup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Creates the initial admin user. Only available when no users exist. */
+        post: operations["setup"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Returns whether initial setup (creating the first admin user) is needed. */
-    get: operations["getSetupStatus"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/logs": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/auth/setup-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns whether initial setup (creating the first admin user) is needed. */
+        get: operations["getSetupStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Lists log events with optional filtering. */
-    get: operations["listLogs"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/logs/boots": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/logs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lists log events with optional filtering. */
+        get: operations["listLogs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Lists distinct boot sessions, newest first. */
-    get: operations["listLogBoots"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/logs/spans": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/logs/boots": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lists distinct boot sessions, newest first. */
+        get: operations["listLogBoots"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Lists tracing spans with optional filtering. */
-    get: operations["listSpans"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/logs/spans/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/logs/spans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lists tracing spans with optional filtering. */
+        get: operations["listSpans"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Returns a single span with its events. */
-    get: operations["getSpan"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/logs/targets": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/logs/spans/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns a single span with its events. */
+        get: operations["getSpan"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Lists distinct log targets for autocomplete. */
-    get: operations["listLogTargets"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/task-definitions": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/logs/targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lists distinct log targets for autocomplete. */
+        get: operations["listLogTargets"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Lists the registered task kinds with their capabilities and JSON Schemas. */
-    get: operations["listTaskDefinitions"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/task-schedules": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/task-definitions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lists the registered task kinds with their capabilities and JSON Schemas. */
+        get: operations["listTaskDefinitions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Lists every periodic task schedule. */
-    get: operations["listTaskSchedules"];
-    put?: never;
-    /** Creates a new periodic task schedule. */
-    post: operations["createTaskSchedule"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/task-schedules/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/task-schedules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lists every periodic task schedule. */
+        get: operations["listTaskSchedules"];
+        put?: never;
+        /** Creates a new periodic task schedule. */
+        post: operations["createTaskSchedule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Returns one task schedule. */
-    get: operations["getTaskSchedule"];
-    put?: never;
-    post?: never;
-    /** Deletes a task schedule. */
-    delete: operations["deleteTaskSchedule"];
-    options?: never;
-    head?: never;
-    /** Updates a task schedule's interval and/or enabled flag. */
-    patch: operations["updateTaskSchedule"];
-    trace?: never;
-  };
-  "/api/v1/tasks": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/task-schedules/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns one task schedule. */
+        get: operations["getTaskSchedule"];
+        put?: never;
+        post?: never;
+        /** Deletes a task schedule. */
+        delete: operations["deleteTaskSchedule"];
+        options?: never;
+        head?: never;
+        /** Updates a task schedule's interval and/or enabled flag. */
+        patch: operations["updateTaskSchedule"];
+        trace?: never;
     };
-    /**
-     * Lists task invocations, optionally filtered by status, kind, and parent.
-     *     Running tasks carry live progress.
-     */
-    get: operations["listTasks"];
-    put?: never;
-    /**
-     * Creates a task of the given kind and starts it.
-     * @description The body input is validated against the kind's input schema.
-     */
-    post: operations["createTask"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/tasks/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Lists task invocations, optionally filtered by status, kind, and parent.
+         *     Running tasks carry live progress.
+         */
+        get: operations["listTasks"];
+        put?: never;
+        /**
+         * Creates a task of the given kind and starts it.
+         * @description The body input is validated against the kind's input schema.
+         */
+        post: operations["createTask"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Returns one task invocation. */
-    get: operations["getTask"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/tasks/{id}/cancel": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/tasks/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns one task invocation. */
+        get: operations["getTask"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Requests cooperative cancellation of a running task. */
-    post: operations["cancelTask"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/users": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/tasks/{id}/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Requests cooperative cancellation of a running task. */
+        post: operations["cancelTask"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Lists all users. */
-    get: operations["listUsers"];
-    put?: never;
-    /** Creates a new user. */
-    post: operations["createUser"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/users/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lists all users. */
+        get: operations["listUsers"];
+        put?: never;
+        /** Creates a new user. */
+        post: operations["createUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Returns one user. */
-    get: operations["getUser"];
-    put?: never;
-    post?: never;
-    /** Deletes a user. */
-    delete: operations["deleteUser"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/version": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/users/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns one user. */
+        get: operations["getUser"];
+        put?: never;
+        post?: never;
+        /** Deletes a user. */
+        delete: operations["deleteUser"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Returns version information about the gateway. */
-    get: operations["getGatewayVersion"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/api/v1/version": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns version information about the gateway. */
+        get: operations["getGatewayVersion"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    /** @description Primary key of a row in the `api_keys` table. */
-    ApiKeyId: string;
-    ApiKeyResponse: {
-      id: string;
-      last_used_at?: string | null;
-      name: string;
-      prefix: string;
-    };
-    /** @description Logical artifact identifier, for example `spectra` or `tls_server-cert`. */
-    ArtifactKey: string;
-    /**
-     * @description A distinct artifact key with its newest version, for `GET
-     *     /api/v1/artifacts`.
-     */
-    ArtifactSummaryResponse: {
-      /** @description Content digest of the newest version. */
-      digest: components["schemas"]["Digest"];
-      /**
-       * Format: date-time
-       * @description When the newest version was downloaded.
-       */
-      downloaded_at: string;
-      /** @description Logical artifact key. */
-      key: string;
-      /**
-       * Format: int64
-       * @description Stored blob size of the newest version, in bytes.
-       */
-      size_bytes: number;
-      /** @description Where the newest version came from. */
-      source: string;
-      /** @description Human-readable version of the newest version, if known. */
-      version?: string | null;
-      /**
-       * Format: int64
-       * @description How many versions of this key are stored.
-       */
-      version_count: number;
-    };
-    /** @description One stored version of an artifact. */
-    ArtifactVersionResponse: {
-      /** @description Content digest of the stored blob. */
-      digest: components["schemas"]["Digest"];
-      /**
-       * Format: date-time
-       * @description When this version was downloaded.
-       */
-      downloaded_at: string;
-      /** @description Logical artifact key. */
-      key: string;
-      media_type?: null | components["schemas"]["MediaType"];
-      /**
-       * Format: int64
-       * @description Stored blob size in bytes.
-       */
-      size_bytes: number;
-      /** @description Where this version came from. */
-      source: string;
-      /**
-       * Format: date-time
-       * @description When this version was last verified, if ever.
-       */
-      verified_at?: string | null;
-      /** @description Human-readable version, if known. */
-      version?: string | null;
-    };
-    /**
-     * @description One boot session observed in the log store, returned by
-     *     `GET /api/v1/logs/boots`.
-     */
-    BootResponse: {
-      /**
-       * Format: uuid
-       * @description Unique boot id (UUID).
-       */
-      boot_id: string;
-      /**
-       * Format: int64
-       * @description Number of events recorded so far in this boot.
-       */
-      event_count: number;
-      /**
-       * Format: date-time
-       * @description Timestamp of the earliest event in this boot.
-       */
-      first_seen: string;
-      /** @description True if this is the currently running gateway boot. */
-      is_current: boolean;
-      /**
-       * Format: date-time
-       * @description Timestamp of the latest event in this boot.
-       */
-      last_seen: string;
-    };
-    ChangePasswordRequest: {
-      current_password: components["schemas"]["Password"];
-      new_password: components["schemas"]["Password"];
-    };
-    CreateApiKeyRequest: {
-      name: string;
-      role?: null | components["schemas"]["Role"];
-    };
-    CreateApiKeyResponse: {
-      id: string;
-      /** @description The full key. Only visible at creation time. */
-      key: components["schemas"]["RawApiKey"];
-      name: string;
-      prefix: string;
-    };
-    CreateTaskInput:
-      | {
-          input: components["schemas"]["DownloadInput"];
-          /** @enum {string} */
-          kind: "download";
-        }
-      | {
-          input: components["schemas"]["RotateCertificateInput"];
-          /** @enum {string} */
-          kind: "rotate-certificate";
+    schemas: {
+        /** @description Primary key of a row in the `api_keys` table. */
+        ApiKeyId: string;
+        ApiKeyResponse: {
+            id: string;
+            last_used_at?: string | null;
+            name: string;
+            prefix: string;
         };
-    /** @description Body for `POST /api/v1/tasks`. */
-    CreateTaskRequest: {
-      /** @description The task input, matching the kind's input schema. */
-      input: unknown;
-      /** @description The kind of task to create. */
-      kind: string;
-    };
-    /** @description Body for `POST /api/v1/task-schedules`. */
-    CreateTaskScheduleRequest: {
-      input: unknown;
-      interval: components["schemas"]["Interval"];
-      kind: string;
-    };
-    CreateUserRequest: {
-      password: components["schemas"]["Password"];
-      role?: null | components["schemas"]["Role"];
-      username: components["schemas"]["Username"];
-    };
-    /** @description Content digest, e.g. `sha256:hex`. */
-    Digest: string;
-    /** @description Input for a download task: what to fetch and where from. */
-    DownloadInput: {
-      /** @description Logical key to record the artifact under. */
-      key: components["schemas"]["ArtifactKey"];
-      /** @description Where and how to fetch it from. */
-      source: components["schemas"]["DownloadSource"];
-    };
-    /** @description Output of a download task: the stored version that resulted. */
-    DownloadOutput: {
-      /** @description Content digest of the stored blob. */
-      digest: components["schemas"]["Digest"];
-      /**
-       * Format: int64
-       * @description Stored blob size in bytes.
-       */
-      size_bytes: number;
-      /** @description Human-readable version, if known. */
-      version?: string | null;
-    };
-    /** @description Where a download fetches from. */
-    DownloadSource: {
-      /** @description The media type of the layer to pull. */
-      media_type: components["schemas"]["MediaType"];
-      /** @description The image reference, for example `ghcr.io/org/image:tag`. */
-      reference: string;
-      /** @enum {string} */
-      type: "oci";
-    };
-    /** @description Primary key of a row in the `log_events` table. */
-    EventId: string;
-    /**
-     * Format: duration
-     * @description A strictly-positive span of time, stored as a whole number of microseconds.
-     *
-     *     On the wire an interval is an ISO 8601 duration such as `PT5M`. Jiff also
-     *     accepts its friendlier form (`5m`) on input.
-     * @example PT5M
-     */
-    Interval: string;
-    /**
-     * @description A structured field filter passed as a string-encoded JSON object in a
-     *     query parameter, e.g. `{"key":"value"}`.
-     *
-     *     The raw string is parsed into key-value pairs during deserialization.
-     * @example {"status":"ok"}
-     */
-    JsonQueryString: string;
-    /**
-     * @description Severity level of a log event or span.
-     * @enum {string}
-     */
-    LevelResponse: "trace" | "debug" | "info" | "warn" | "error";
-    /** @description A single log event, returned by `GET /api/v1/logs`. */
-    LogEventResponse: {
-      /**
-       * Format: uuid
-       * @description Boot session this event belongs to, if known.
-       */
-      boot_id: string;
-      /** @description Structured fields as a JSON object, if any. */
-      fields: {
-        [key: string]: unknown;
-      };
-      /** @description Source file, if available. */
-      file?: string | null;
-      /** @description Event id. */
-      id: components["schemas"]["EventId"];
-      /** @description Severity level. */
-      level: components["schemas"]["LevelResponse"];
-      /**
-       * Format: int32
-       * @description Source line, if available.
-       */
-      line?: number | null;
-      /** @description Human-readable message, if any. */
-      message?: string | null;
-      span_id?: null | components["schemas"]["SpanId"];
-      /** @description Module path that emitted the event. */
-      target: string;
-      /**
-       * Format: date-time
-       * @description When the event was emitted.
-       */
-      timestamp: string;
-    };
-    /** @description A span with its child events, returned by `GET /api/v1/logs/spans/{id}`. */
-    LogSpanDetailResponse: components["schemas"]["LogSpanResponse"] & {
-      /** @description Events belonging to this span, ordered by timestamp. */
-      events: components["schemas"]["LogEventResponse"][];
-    };
-    /** @description A tracing span, returned by `GET /api/v1/logs/spans`. */
-    LogSpanResponse: {
-      /**
-       * Format: date-time
-       * @description When the span ended, if it did.
-       */
-      ended_at?: string | null;
-      /** @description Span fields as a JSON object, if any. */
-      fields: {
-        [key: string]: unknown;
-      };
-      /** @description Source file, if available. */
-      file?: string | null;
-      /** @description Span id. */
-      id: components["schemas"]["SpanId"];
-      /** @description Severity level. */
-      level: components["schemas"]["LevelResponse"];
-      /**
-       * Format: int32
-       * @description Source line, if available.
-       */
-      line?: number | null;
-      /** @description Span name. */
-      name: string;
-      parent_id?: null | components["schemas"]["SpanId"];
-      /**
-       * Format: date-time
-       * @description When the span started.
-       */
-      started_at: string;
-      /** @description Module path that created the span. */
-      target: string;
-    };
-    LoginRequest: {
-      password: components["schemas"]["Password"];
-      username: components["schemas"]["Username"];
-    };
-    LoginResponse: {
-      must_change_password: boolean;
-    };
-    /** @description A bare 'type/subtype' media type with no parameters. */
-    MediaType: string;
-    /**
-     * @description Sort direction shared by list endpoints.
-     * @enum {string}
-     */
-    OrderParam: "asc" | "desc";
-    /** @description A page of results plus the cursors for the neighbouring pages. */
-    Page_ArtifactSummaryResponse: {
-      /** @description The rows in this page. */
-      items: {
-        /** @description Content digest of the newest version. */
-        digest: components["schemas"]["Digest"];
+        /** @description Logical artifact identifier, for example `spectra` or `tls_server-cert`. */
+        ArtifactKey: string;
         /**
-         * Format: date-time
-         * @description When the newest version was downloaded.
+         * @description A distinct artifact key with its newest version, for `GET
+         *     /api/v1/artifacts`.
          */
-        downloaded_at: string;
-        /** @description Logical artifact key. */
-        key: string;
-        /**
-         * Format: int64
-         * @description Stored blob size of the newest version, in bytes.
-         */
-        size_bytes: number;
-        /** @description Where the newest version came from. */
-        source: string;
-        /** @description Human-readable version of the newest version, if known. */
-        version?: string | null;
-        /**
-         * Format: int64
-         * @description How many versions of this key are stored.
-         */
-        version_count: number;
-      }[];
-      /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
-      next_cursor?: string | null;
-      /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
-      prev_cursor?: string | null;
-    };
-    /** @description A page of results plus the cursors for the neighbouring pages. */
-    Page_ArtifactVersionResponse: {
-      /** @description The rows in this page. */
-      items: {
-        /** @description Content digest of the stored blob. */
-        digest: components["schemas"]["Digest"];
-        /**
-         * Format: date-time
-         * @description When this version was downloaded.
-         */
-        downloaded_at: string;
-        /** @description Logical artifact key. */
-        key: string;
-        media_type?: null | components["schemas"]["MediaType"];
-        /**
-         * Format: int64
-         * @description Stored blob size in bytes.
-         */
-        size_bytes: number;
-        /** @description Where this version came from. */
-        source: string;
-        /**
-         * Format: date-time
-         * @description When this version was last verified, if ever.
-         */
-        verified_at?: string | null;
-        /** @description Human-readable version, if known. */
-        version?: string | null;
-      }[];
-      /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
-      next_cursor?: string | null;
-      /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
-      prev_cursor?: string | null;
-    };
-    /** @description A page of results plus the cursors for the neighbouring pages. */
-    Page_LogEventResponse: {
-      /** @description The rows in this page. */
-      items: {
-        /**
-         * Format: uuid
-         * @description Boot session this event belongs to, if known.
-         */
-        boot_id: string;
-        /** @description Structured fields as a JSON object, if any. */
-        fields: {
-          [key: string]: unknown;
+        ArtifactSummaryResponse: {
+            /** @description Content digest of the newest version. */
+            digest: components["schemas"]["Digest"];
+            /**
+             * Format: date-time
+             * @description When the newest version was downloaded.
+             */
+            downloaded_at: string;
+            /** @description Logical artifact key. */
+            key: string;
+            /**
+             * Format: int64
+             * @description Stored blob size of the newest version, in bytes.
+             */
+            size_bytes: number;
+            /** @description Where the newest version came from. */
+            source: string;
+            /** @description Human-readable version of the newest version, if known. */
+            version?: string | null;
+            /**
+             * Format: int64
+             * @description How many versions of this key are stored.
+             */
+            version_count: number;
         };
-        /** @description Source file, if available. */
-        file?: string | null;
-        /** @description Event id. */
-        id: components["schemas"]["EventId"];
-        /** @description Severity level. */
-        level: components["schemas"]["LevelResponse"];
-        /**
-         * Format: int32
-         * @description Source line, if available.
-         */
-        line?: number | null;
-        /** @description Human-readable message, if any. */
-        message?: string | null;
-        span_id?: null | components["schemas"]["SpanId"];
-        /** @description Module path that emitted the event. */
-        target: string;
-        /**
-         * Format: date-time
-         * @description When the event was emitted.
-         */
-        timestamp: string;
-      }[];
-      /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
-      next_cursor?: string | null;
-      /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
-      prev_cursor?: string | null;
-    };
-    /** @description A page of results plus the cursors for the neighbouring pages. */
-    Page_LogSpanResponse: {
-      /** @description The rows in this page. */
-      items: {
-        /**
-         * Format: date-time
-         * @description When the span ended, if it did.
-         */
-        ended_at?: string | null;
-        /** @description Span fields as a JSON object, if any. */
-        fields: {
-          [key: string]: unknown;
+        /** @description One stored version of an artifact. */
+        ArtifactVersionResponse: {
+            /** @description Content digest of the stored blob. */
+            digest: components["schemas"]["Digest"];
+            /**
+             * Format: date-time
+             * @description When this version was downloaded.
+             */
+            downloaded_at: string;
+            /** @description Logical artifact key. */
+            key: string;
+            media_type?: null | components["schemas"]["MediaType"];
+            /**
+             * Format: int64
+             * @description Stored blob size in bytes.
+             */
+            size_bytes: number;
+            /** @description Where this version came from. */
+            source: string;
+            /**
+             * Format: date-time
+             * @description When this version was last verified, if ever.
+             */
+            verified_at?: string | null;
+            /** @description Human-readable version, if known. */
+            version?: string | null;
         };
-        /** @description Source file, if available. */
-        file?: string | null;
-        /** @description Span id. */
-        id: components["schemas"]["SpanId"];
-        /** @description Severity level. */
-        level: components["schemas"]["LevelResponse"];
         /**
-         * Format: int32
-         * @description Source line, if available.
+         * @description One boot session observed in the log store, returned by
+         *     `GET /api/v1/logs/boots`.
          */
-        line?: number | null;
-        /** @description Span name. */
-        name: string;
-        parent_id?: null | components["schemas"]["SpanId"];
+        BootResponse: {
+            /**
+             * Format: uuid
+             * @description Unique boot id (UUID).
+             */
+            boot_id: string;
+            /**
+             * Format: int64
+             * @description Number of events recorded so far in this boot.
+             */
+            event_count: number;
+            /**
+             * Format: date-time
+             * @description Timestamp of the earliest event in this boot.
+             */
+            first_seen: string;
+            /** @description True if this is the currently running gateway boot. */
+            is_current: boolean;
+            /**
+             * Format: date-time
+             * @description Timestamp of the latest event in this boot.
+             */
+            last_seen: string;
+        };
+        ChangePasswordRequest: {
+            current_password: components["schemas"]["Password"];
+            new_password: components["schemas"]["Password"];
+        };
+        CreateApiKeyRequest: {
+            name: string;
+            role?: null | components["schemas"]["Role"];
+        };
+        CreateApiKeyResponse: {
+            id: string;
+            /** @description The full key. Only visible at creation time. */
+            key: components["schemas"]["RawApiKey"];
+            name: string;
+            prefix: string;
+        };
+        CreateTaskInput: {
+            input: components["schemas"]["RotateCertificateInput"];
+            /** @enum {string} */
+            kind: "rotate-certificate";
+        } | {
+            input: components["schemas"]["DownloadInput"];
+            /** @enum {string} */
+            kind: "download";
+        };
+        /** @description Body for `POST /api/v1/tasks`. */
+        CreateTaskRequest: {
+            /** @description The task input, matching the kind's input schema. */
+            input: unknown;
+            /** @description The kind of task to create. */
+            kind: string;
+        };
+        /** @description Body for `POST /api/v1/task-schedules`. */
+        CreateTaskScheduleRequest: {
+            input: unknown;
+            interval: components["schemas"]["Interval"];
+            kind: string;
+        };
+        CreateUserRequest: {
+            password: components["schemas"]["Password"];
+            role?: null | components["schemas"]["Role"];
+            username: components["schemas"]["Username"];
+        };
+        CurrentUserResponse: {
+            actor_id: string;
+            display_name: string;
+            must_change_password: boolean;
+            role?: null | components["schemas"]["Role"];
+            username?: string | null;
+        };
+        /** @description Content digest, e.g. `sha256:hex`. */
+        Digest: string;
+        /** @description Input for a download task: what to fetch and where from. */
+        DownloadInput: {
+            /** @description Logical key to record the artifact under. */
+            key: components["schemas"]["ArtifactKey"];
+            /** @description Where and how to fetch it from. */
+            source: components["schemas"]["DownloadSource"];
+        };
+        /** @description Output of a download task: the stored version that resulted. */
+        DownloadOutput: {
+            /** @description Content digest of the stored blob. */
+            digest: components["schemas"]["Digest"];
+            /**
+             * Format: int64
+             * @description Stored blob size in bytes.
+             */
+            size_bytes: number;
+            /** @description Human-readable version, if known. */
+            version?: string | null;
+        };
+        /** @description Where a download fetches from. */
+        DownloadSource: {
+            /** @description The media type of the layer to pull. */
+            media_type: components["schemas"]["MediaType"];
+            /** @description The image reference, for example `ghcr.io/org/image:tag`. */
+            reference: string;
+            /** @enum {string} */
+            type: "oci";
+        };
+        /** @description Primary key of a row in the `log_events` table. */
+        EventId: string;
         /**
-         * Format: date-time
-         * @description When the span started.
+         * Format: duration
+         * @description A strictly-positive span of time, stored as a whole number of microseconds.
+         *
+         *     On the wire an interval is an ISO 8601 duration such as `PT5M`. Jiff also
+         *     accepts its friendlier form (`5m`) on input.
+         * @example PT5M
          */
-        started_at: string;
-        /** @description Module path that created the span. */
-        target: string;
-      }[];
-      /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
-      next_cursor?: string | null;
-      /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
-      prev_cursor?: string | null;
-    };
-    /** @description A page of results plus the cursors for the neighbouring pages. */
-    Page_TaskResponse: {
-      /** @description The rows in this page. */
-      items: {
+        Interval: string;
         /**
-         * Format: date-time
-         * @description When the invocation was recorded.
+         * @description A structured field filter passed as a string-encoded JSON object in a
+         *     query parameter, e.g. `{"key":"value"}`.
+         *
+         *     The raw string is parsed into key-value pairs during deserialization.
+         * @example {"status":"ok"}
          */
-        created_at: string;
-        /** @description Failure detail, if any. */
-        error?: string | null;
+        JsonQueryString: string;
         /**
-         * Format: date-time
-         * @description When it finished, if it did.
+         * @description Severity level of a log event or span.
+         * @enum {string}
          */
-        finished_at?: string | null;
-        /** @description Invocation id. */
-        id: components["schemas"]["TaskId"];
-        /** @description The input the task was created with. */
-        input: unknown;
-        /** @description The kind of task. */
-        kind: string;
-        /** @description The output, once the task succeeds. */
-        output?: unknown;
-        parent_id?: null | components["schemas"]["TaskId"];
-        progress?: null | components["schemas"]["ProgressResponse"];
+        LevelResponse: "trace" | "debug" | "info" | "warn" | "error";
+        /** @description A single log event, returned by `GET /api/v1/logs`. */
+        LogEventResponse: {
+            /**
+             * Format: uuid
+             * @description Boot session this event belongs to, if known.
+             */
+            boot_id: string;
+            /** @description Structured fields as a JSON object, if any. */
+            fields: {
+                [key: string]: unknown;
+            };
+            /** @description Source file, if available. */
+            file?: string | null;
+            /** @description Event id. */
+            id: components["schemas"]["EventId"];
+            /** @description Severity level. */
+            level: components["schemas"]["LevelResponse"];
+            /**
+             * Format: int32
+             * @description Source line, if available.
+             */
+            line?: number | null;
+            /** @description Human-readable message, if any. */
+            message?: string | null;
+            span_id?: null | components["schemas"]["SpanId"];
+            /** @description Module path that emitted the event. */
+            target: string;
+            /**
+             * Format: date-time
+             * @description When the event was emitted.
+             */
+            timestamp: string;
+        };
+        /** @description A span with its child events, returned by `GET /api/v1/logs/spans/{id}`. */
+        LogSpanDetailResponse: components["schemas"]["LogSpanResponse"] & {
+            /** @description Events belonging to this span, ordered by timestamp. */
+            events: components["schemas"]["LogEventResponse"][];
+        };
+        /** @description A tracing span, returned by `GET /api/v1/logs/spans`. */
+        LogSpanResponse: {
+            /**
+             * Format: date-time
+             * @description When the span ended, if it did.
+             */
+            ended_at?: string | null;
+            /** @description Span fields as a JSON object, if any. */
+            fields: {
+                [key: string]: unknown;
+            };
+            /** @description Source file, if available. */
+            file?: string | null;
+            /** @description Span id. */
+            id: components["schemas"]["SpanId"];
+            /** @description Severity level. */
+            level: components["schemas"]["LevelResponse"];
+            /**
+             * Format: int32
+             * @description Source line, if available.
+             */
+            line?: number | null;
+            /** @description Span name. */
+            name: string;
+            parent_id?: null | components["schemas"]["SpanId"];
+            /**
+             * Format: date-time
+             * @description When the span started.
+             */
+            started_at: string;
+            /** @description Module path that created the span. */
+            target: string;
+        };
+        LoginRequest: {
+            password: components["schemas"]["Password"];
+            username: components["schemas"]["Username"];
+        };
+        LoginResponse: {
+            must_change_password: boolean;
+        };
+        /** @description A bare 'type/subtype' media type with no parameters. */
+        MediaType: string;
         /**
-         * Format: date-time
-         * @description When it started running, if it did.
+         * @description Sort direction shared by list endpoints.
+         * @enum {string}
          */
-        started_at?: string | null;
-        /** @description Lifecycle state. */
-        status: components["schemas"]["TaskStatusResponse"];
-      }[];
-      /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
-      next_cursor?: string | null;
-      /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
-      prev_cursor?: string | null;
+        OrderParam: "asc" | "desc";
+        /** @description A page of results plus the cursors for the neighbouring pages. */
+        Page_ArtifactSummaryResponse: {
+            /** @description The rows in this page. */
+            items: {
+                /** @description Content digest of the newest version. */
+                digest: components["schemas"]["Digest"];
+                /**
+                 * Format: date-time
+                 * @description When the newest version was downloaded.
+                 */
+                downloaded_at: string;
+                /** @description Logical artifact key. */
+                key: string;
+                /**
+                 * Format: int64
+                 * @description Stored blob size of the newest version, in bytes.
+                 */
+                size_bytes: number;
+                /** @description Where the newest version came from. */
+                source: string;
+                /** @description Human-readable version of the newest version, if known. */
+                version?: string | null;
+                /**
+                 * Format: int64
+                 * @description How many versions of this key are stored.
+                 */
+                version_count: number;
+            }[];
+            /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
+            next_cursor?: string | null;
+            /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
+            prev_cursor?: string | null;
+        };
+        /** @description A page of results plus the cursors for the neighbouring pages. */
+        Page_ArtifactVersionResponse: {
+            /** @description The rows in this page. */
+            items: {
+                /** @description Content digest of the stored blob. */
+                digest: components["schemas"]["Digest"];
+                /**
+                 * Format: date-time
+                 * @description When this version was downloaded.
+                 */
+                downloaded_at: string;
+                /** @description Logical artifact key. */
+                key: string;
+                media_type?: null | components["schemas"]["MediaType"];
+                /**
+                 * Format: int64
+                 * @description Stored blob size in bytes.
+                 */
+                size_bytes: number;
+                /** @description Where this version came from. */
+                source: string;
+                /**
+                 * Format: date-time
+                 * @description When this version was last verified, if ever.
+                 */
+                verified_at?: string | null;
+                /** @description Human-readable version, if known. */
+                version?: string | null;
+            }[];
+            /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
+            next_cursor?: string | null;
+            /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
+            prev_cursor?: string | null;
+        };
+        /** @description A page of results plus the cursors for the neighbouring pages. */
+        Page_LogEventResponse: {
+            /** @description The rows in this page. */
+            items: {
+                /**
+                 * Format: uuid
+                 * @description Boot session this event belongs to, if known.
+                 */
+                boot_id: string;
+                /** @description Structured fields as a JSON object, if any. */
+                fields: {
+                    [key: string]: unknown;
+                };
+                /** @description Source file, if available. */
+                file?: string | null;
+                /** @description Event id. */
+                id: components["schemas"]["EventId"];
+                /** @description Severity level. */
+                level: components["schemas"]["LevelResponse"];
+                /**
+                 * Format: int32
+                 * @description Source line, if available.
+                 */
+                line?: number | null;
+                /** @description Human-readable message, if any. */
+                message?: string | null;
+                span_id?: null | components["schemas"]["SpanId"];
+                /** @description Module path that emitted the event. */
+                target: string;
+                /**
+                 * Format: date-time
+                 * @description When the event was emitted.
+                 */
+                timestamp: string;
+            }[];
+            /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
+            next_cursor?: string | null;
+            /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
+            prev_cursor?: string | null;
+        };
+        /** @description A page of results plus the cursors for the neighbouring pages. */
+        Page_LogSpanResponse: {
+            /** @description The rows in this page. */
+            items: {
+                /**
+                 * Format: date-time
+                 * @description When the span ended, if it did.
+                 */
+                ended_at?: string | null;
+                /** @description Span fields as a JSON object, if any. */
+                fields: {
+                    [key: string]: unknown;
+                };
+                /** @description Source file, if available. */
+                file?: string | null;
+                /** @description Span id. */
+                id: components["schemas"]["SpanId"];
+                /** @description Severity level. */
+                level: components["schemas"]["LevelResponse"];
+                /**
+                 * Format: int32
+                 * @description Source line, if available.
+                 */
+                line?: number | null;
+                /** @description Span name. */
+                name: string;
+                parent_id?: null | components["schemas"]["SpanId"];
+                /**
+                 * Format: date-time
+                 * @description When the span started.
+                 */
+                started_at: string;
+                /** @description Module path that created the span. */
+                target: string;
+            }[];
+            /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
+            next_cursor?: string | null;
+            /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
+            prev_cursor?: string | null;
+        };
+        /** @description A page of results plus the cursors for the neighbouring pages. */
+        Page_TaskResponse: {
+            /** @description The rows in this page. */
+            items: {
+                /**
+                 * Format: date-time
+                 * @description When the invocation was recorded.
+                 */
+                created_at: string;
+                /** @description Failure detail, if any. */
+                error?: string | null;
+                /**
+                 * Format: date-time
+                 * @description When it finished, if it did.
+                 */
+                finished_at?: string | null;
+                /** @description Invocation id. */
+                id: components["schemas"]["TaskId"];
+                /** @description The input the task was created with. */
+                input: unknown;
+                /** @description The kind of task. */
+                kind: string;
+                /** @description The output, once the task succeeds. */
+                output?: unknown;
+                parent_id?: null | components["schemas"]["TaskId"];
+                progress?: null | components["schemas"]["ProgressResponse"];
+                /**
+                 * Format: date-time
+                 * @description When it started running, if it did.
+                 */
+                started_at?: string | null;
+                /** @description Lifecycle state. */
+                status: components["schemas"]["TaskStatusResponse"];
+            }[];
+            /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
+            next_cursor?: string | null;
+            /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
+            prev_cursor?: string | null;
+        };
+        /** @description A page of results plus the cursors for the neighbouring pages. */
+        Page_TaskScheduleResponse: {
+            /** @description The rows in this page. */
+            items: {
+                /** Format: date-time */
+                created_at: string;
+                enabled: boolean;
+                id: components["schemas"]["TaskScheduleId"];
+                input: unknown;
+                interval: components["schemas"]["Interval"];
+                kind: string;
+                /** Format: date-time */
+                last_run_at?: string | null;
+                last_task_id?: null | components["schemas"]["TaskId"];
+                /** Format: date-time */
+                next_run_at: string;
+            }[];
+            /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
+            next_cursor?: string | null;
+            /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
+            prev_cursor?: string | null;
+        };
+        /**
+         * @description A plaintext password. Redacts in Debug output to avoid accidental leakage.
+         *
+         *     Unlike [`Username`](crate::Username), `Password` does NOT validate on
+         *     construction or deserialization. This is deliberate: the login handler must
+         *     accept any password string (even one below the minimum length) so the
+         *     request reaches the handler body where the rate limiter is consulted.
+         *     Validating at deserialization would let an attacker bypass rate limiting
+         *     by sending short passwords (they would be rejected with a 400 before the
+         *     handler runs). Password validation happens in
+         *     [`AuthHandle`](crate::AuthHandle) methods (`create_user`,
+         *     `change_password`, `setup_admin`) instead.
+         */
+        Password: string;
+        /** @description A localizable progress message: a translation key and its arguments. */
+        ProgressMessageResponse: {
+            /** @description Arguments to interpolate into the resolved message. */
+            args: {
+                [key: string]: string;
+            };
+            /** @description Translation key for the current step. */
+            key: string;
+        };
+        /** @description Live progress of a running task. */
+        ProgressResponse: {
+            /**
+             * Format: int64
+             * @description Units of work completed so far.
+             */
+            done?: number | null;
+            message?: null | components["schemas"]["ProgressMessageResponse"];
+            /**
+             * Format: int64
+             * @description Total units of work expected, if known.
+             */
+            total?: number | null;
+        };
+        /** @description A raw API key. Redacts in Debug output. */
+        RawApiKey: string;
+        /**
+         * @description A built-in role. Stored as its lowercase name in casbin grouping rules.
+         * @enum {string}
+         */
+        Role: "admin" | "operator" | "viewer";
+        /** @description Rotation takes no parameters (identity-preserving). */
+        RotateCertificateInput: Record<string, never>;
+        RotateCertificateOutput: {
+            /** @description Whether the leaf was actually re-issued. */
+            rotated: boolean;
+        };
+        SetupRequest: {
+            password: components["schemas"]["Password"];
+            username: components["schemas"]["Username"];
+        };
+        SetupStatusResponse: {
+            setup_required: boolean;
+        };
+        /** @description Primary key of a row in the `log_spans` table. */
+        SpanId: string;
+        /** @description A registered task kind, with its capabilities and JSON Schemas. */
+        TaskDefinitionResponse: {
+            /** @description Whether the kind can be cancelled. */
+            cancellable: boolean;
+            /** @description JSON Schema of the kind's input. */
+            input_schema: unknown;
+            /** @description The kind string. */
+            kind: string;
+            /** @description JSON Schema of the kind's output. */
+            output_schema: unknown;
+            /** @description Whether the kind is safe to interrupt across a restart. */
+            resumable: boolean;
+        };
+        /** @description Primary key of a row in the `tasks` table. */
+        TaskId: string;
+        /** @description One task invocation, returned by the task endpoints. */
+        TaskResponse: {
+            /**
+             * Format: date-time
+             * @description When the invocation was recorded.
+             */
+            created_at: string;
+            /** @description Failure detail, if any. */
+            error?: string | null;
+            /**
+             * Format: date-time
+             * @description When it finished, if it did.
+             */
+            finished_at?: string | null;
+            /** @description Invocation id. */
+            id: components["schemas"]["TaskId"];
+            /** @description The input the task was created with. */
+            input: unknown;
+            /** @description The kind of task. */
+            kind: string;
+            /** @description The output, once the task succeeds. */
+            output?: unknown;
+            parent_id?: null | components["schemas"]["TaskId"];
+            progress?: null | components["schemas"]["ProgressResponse"];
+            /**
+             * Format: date-time
+             * @description When it started running, if it did.
+             */
+            started_at?: string | null;
+            /** @description Lifecycle state. */
+            status: components["schemas"]["TaskStatusResponse"];
+        };
+        /** @description Primary key of a row in the `task_schedules` table. */
+        TaskScheduleId: string;
+        TaskScheduleResponse: {
+            /** Format: date-time */
+            created_at: string;
+            enabled: boolean;
+            id: components["schemas"]["TaskScheduleId"];
+            input: unknown;
+            interval: components["schemas"]["Interval"];
+            kind: string;
+            /** Format: date-time */
+            last_run_at?: string | null;
+            last_task_id?: null | components["schemas"]["TaskId"];
+            /** Format: date-time */
+            next_run_at: string;
+        };
+        /**
+         * @description Filter for task status, including the `active` and `finished` groups.
+         * @enum {string}
+         */
+        TaskStatusParam: "active" | "finished" | "pending" | "running" | "succeeded" | "failed" | "cancelled" | "interrupted";
+        /**
+         * @description Lifecycle state of a task invocation.
+         * @enum {string}
+         */
+        TaskStatusResponse: "pending" | "running" | "succeeded" | "failed" | "cancelled" | "interrupted";
+        /** @description Body for `PATCH /api/v1/task-schedules/{id}`. */
+        UpdateTaskScheduleRequest: {
+            enabled?: boolean | null;
+            interval?: null | components["schemas"]["Interval"];
+        };
+        /** @description Primary key of a row in the `users` table. */
+        UserId: string;
+        UserResponse: {
+            actor_id: string;
+            id: string;
+            must_change_password: boolean;
+            username: string;
+        };
+        /**
+         * @description A login name that is guaranteed valid by construction.
+         *
+         *     Allowed characters are ASCII letters, digits, and `_`, `-`, `.`. The length
+         *     is bounded to 1..=64 characters. Because validation runs in [`TryFrom`] (and
+         *     therefore during deserialization), a request body with an invalid username
+         *     is rejected at the extractor boundary with a `400` before any handler runs.
+         */
+        Username: string;
+        /** @description Version information returned by `GET /api/v1/version`. */
+        VersionResponse: {
+            /** @description Version of the Aperture gateway. */
+            aperture: string;
+            /**
+             * Format: uuid
+             * @description Unique id of this gateway boot session.
+             */
+            boot_id: string;
+        };
+        /**
+         * @description Field a version listing is sorted by.
+         * @enum {string}
+         */
+        VersionSortParam: "downloaded_at" | "size_bytes";
     };
-    /** @description A page of results plus the cursors for the neighbouring pages. */
-    Page_TaskScheduleResponse: {
-      /** @description The rows in this page. */
-      items: {
-        /** Format: date-time */
-        created_at: string;
-        enabled: boolean;
-        id: components["schemas"]["TaskScheduleId"];
-        input: unknown;
-        interval: components["schemas"]["Interval"];
-        kind: string;
-        /** Format: date-time */
-        last_run_at?: string | null;
-        last_task_id?: null | components["schemas"]["TaskId"];
-        /** Format: date-time */
-        next_run_at: string;
-      }[];
-      /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
-      next_cursor?: string | null;
-      /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
-      prev_cursor?: string | null;
-    };
-    /**
-     * @description A plaintext password. Redacts in Debug output to avoid accidental leakage.
-     *
-     *     Unlike [`Username`](crate::Username), `Password` does NOT validate on
-     *     construction or deserialization. This is deliberate: the login handler must
-     *     accept any password string (even one below the minimum length) so the
-     *     request reaches the handler body where the rate limiter is consulted.
-     *     Validating at deserialization would let an attacker bypass rate limiting
-     *     by sending short passwords (they would be rejected with a 400 before the
-     *     handler runs). Password validation happens in
-     *     [`AuthHandle`](crate::AuthHandle) methods (`create_user`,
-     *     `change_password`, `setup_admin`) instead.
-     */
-    Password: string;
-    /** @description A localizable progress message: a translation key and its arguments. */
-    ProgressMessageResponse: {
-      /** @description Arguments to interpolate into the resolved message. */
-      args: {
-        [key: string]: string;
-      };
-      /** @description Translation key for the current step. */
-      key: string;
-    };
-    /** @description Live progress of a running task. */
-    ProgressResponse: {
-      /**
-       * Format: int64
-       * @description Units of work completed so far.
-       */
-      done?: number | null;
-      message?: null | components["schemas"]["ProgressMessageResponse"];
-      /**
-       * Format: int64
-       * @description Total units of work expected, if known.
-       */
-      total?: number | null;
-    };
-    /** @description A raw API key. Redacts in Debug output. */
-    RawApiKey: string;
-    /**
-     * @description A built-in role. Stored as its lowercase name in casbin grouping rules.
-     * @enum {string}
-     */
-    Role: "admin" | "operator" | "viewer";
-    /** @description Rotation takes no parameters (identity-preserving). */
-    RotateCertificateInput: Record<string, never>;
-    RotateCertificateOutput: {
-      /** @description Whether the leaf was actually re-issued. */
-      rotated: boolean;
-    };
-    SetupRequest: {
-      password: components["schemas"]["Password"];
-      username: components["schemas"]["Username"];
-    };
-    SetupStatusResponse: {
-      setup_required: boolean;
-    };
-    /** @description Primary key of a row in the `log_spans` table. */
-    SpanId: string;
-    /** @description A registered task kind, with its capabilities and JSON Schemas. */
-    TaskDefinitionResponse: {
-      /** @description Whether the kind can be cancelled. */
-      cancellable: boolean;
-      /** @description JSON Schema of the kind's input. */
-      input_schema: unknown;
-      /** @description The kind string. */
-      kind: string;
-      /** @description JSON Schema of the kind's output. */
-      output_schema: unknown;
-      /** @description Whether the kind is safe to interrupt across a restart. */
-      resumable: boolean;
-    };
-    /** @description Primary key of a row in the `tasks` table. */
-    TaskId: string;
-    /** @description One task invocation, returned by the task endpoints. */
-    TaskResponse: {
-      /**
-       * Format: date-time
-       * @description When the invocation was recorded.
-       */
-      created_at: string;
-      /** @description Failure detail, if any. */
-      error?: string | null;
-      /**
-       * Format: date-time
-       * @description When it finished, if it did.
-       */
-      finished_at?: string | null;
-      /** @description Invocation id. */
-      id: components["schemas"]["TaskId"];
-      /** @description The input the task was created with. */
-      input: unknown;
-      /** @description The kind of task. */
-      kind: string;
-      /** @description The output, once the task succeeds. */
-      output?: unknown;
-      parent_id?: null | components["schemas"]["TaskId"];
-      progress?: null | components["schemas"]["ProgressResponse"];
-      /**
-       * Format: date-time
-       * @description When it started running, if it did.
-       */
-      started_at?: string | null;
-      /** @description Lifecycle state. */
-      status: components["schemas"]["TaskStatusResponse"];
-    };
-    /** @description Primary key of a row in the `task_schedules` table. */
-    TaskScheduleId: string;
-    TaskScheduleResponse: {
-      /** Format: date-time */
-      created_at: string;
-      enabled: boolean;
-      id: components["schemas"]["TaskScheduleId"];
-      input: unknown;
-      interval: components["schemas"]["Interval"];
-      kind: string;
-      /** Format: date-time */
-      last_run_at?: string | null;
-      last_task_id?: null | components["schemas"]["TaskId"];
-      /** Format: date-time */
-      next_run_at: string;
-    };
-    /**
-     * @description Filter for task status, including the `active` and `finished` groups.
-     * @enum {string}
-     */
-    TaskStatusParam:
-      | "active"
-      | "finished"
-      | "pending"
-      | "running"
-      | "succeeded"
-      | "failed"
-      | "cancelled"
-      | "interrupted";
-    /**
-     * @description Lifecycle state of a task invocation.
-     * @enum {string}
-     */
-    TaskStatusResponse:
-      "pending" | "running" | "succeeded" | "failed" | "cancelled" | "interrupted";
-    /** @description Body for `PATCH /api/v1/task-schedules/{id}`. */
-    UpdateTaskScheduleRequest: {
-      enabled?: boolean | null;
-      interval?: null | components["schemas"]["Interval"];
-    };
-    /** @description Primary key of a row in the `users` table. */
-    UserId: string;
-    UserResponse: {
-      actor_id: string;
-      id: string;
-      must_change_password: boolean;
-      username: string;
-    };
-    /**
-     * @description A login name that is guaranteed valid by construction.
-     *
-     *     Allowed characters are ASCII letters, digits, and `_`, `-`, `.`. The length
-     *     is bounded to 1..=64 characters. Because validation runs in [`TryFrom`] (and
-     *     therefore during deserialization), a request body with an invalid username
-     *     is rejected at the extractor boundary with a `400` before any handler runs.
-     */
-    Username: string;
-    /** @description Version information returned by `GET /api/v1/version`. */
-    VersionResponse: {
-      /** @description Version of the Aperture gateway. */
-      aperture: string;
-      /**
-       * Format: uuid
-       * @description Unique id of this gateway boot session.
-       */
-      boot_id: string;
-    };
-    /**
-     * @description Field a version listing is sorted by.
-     * @enum {string}
-     */
-    VersionSortParam: "downloaded_at" | "size_bytes";
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  listApiKeys: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description API keys */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ApiKeyResponse"][];
-        };
-      };
-    };
-  };
-  createApiKey: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateApiKeyRequest"];
-      };
-    };
-    responses: {
-      /** @description API key created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["CreateApiKeyResponse"];
-        };
-      };
-    };
-  };
-  deleteApiKey: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description API key id */
-        id: components["schemas"]["ApiKeyId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description API key deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Unknown API key */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  listArtifacts: {
-    parameters: {
-      query?: {
-        /** @description Maximum rows to return. Defaults to 50. */
-        limit?: number;
-        /** @description Cursor from a page's `next_cursor` or `prev_cursor`. */
-        cursor?: string;
-        /** @description Sort direction. */
-        order?: components["schemas"]["OrderParam"];
-        /** @description Match keys containing this substring. */
-        q?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Artifacts */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Page_ArtifactSummaryResponse"];
-        };
-      };
-    };
-  };
-  getArtifact: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Artifact key */
-        key: components["schemas"]["ArtifactKey"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Artifact */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ArtifactSummaryResponse"];
-        };
-      };
-      /** @description Unknown artifact */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  uploadArtifact: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Artifact key */
-        key: components["schemas"]["ArtifactKey"];
-      };
-      cookie?: never;
-    };
-    /** @description Raw artifact bytes to store */
-    requestBody?: {
-      content: {
-        "application/octet-stream": unknown;
-      };
-    };
-    responses: {
-      /** @description Version stored */
-      201: {
-        headers: {
-          /** @description Path to the newly stored version */
-          Location?: string;
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ArtifactVersionResponse"];
-        };
-      };
-      /** @description Body exceeded the maximum upload size */
-      413: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  listArtifactVersions: {
-    parameters: {
-      query?: {
-        /** @description Maximum rows to return. Defaults to 50. */
-        limit?: number;
-        /** @description Cursor from a page's `next_cursor` or `prev_cursor`. */
-        cursor?: string;
-        /** @description Sort direction. */
-        order?: components["schemas"]["OrderParam"];
-        /** @description Field to sort by. Defaults to downloaded time. */
-        sort?: components["schemas"]["VersionSortParam"];
-        /** @description Only versions with this exact media type. */
-        media_type?: components["schemas"]["MediaType"];
-        /** @description Only versions with this exact version string. */
-        version?: string;
-      };
-      header?: never;
-      path: {
-        /** @description Artifact key */
-        key: components["schemas"]["ArtifactKey"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Versions */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Page_ArtifactVersionResponse"];
-        };
-      };
-    };
-  };
-  getArtifactVersion: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Artifact key */
-        key: components["schemas"]["ArtifactKey"];
-        /** @description Content digest */
-        digest: components["schemas"]["Digest"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Version */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ArtifactVersionResponse"];
-        };
-      };
-      /** @description Unknown version */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  deleteArtifactVersion: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Artifact key */
-        key: components["schemas"]["ArtifactKey"];
-        /** @description Content digest */
-        digest: components["schemas"]["Digest"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Version evicted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Unknown version */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  downloadArtifactBlob: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Artifact key */
-        key: components["schemas"]["ArtifactKey"];
-        /** @description Content digest */
-        digest: components["schemas"]["Digest"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Blob content */
-      200: {
-        headers: {
-          /** @description Immutable caching directive */
-          "Cache-Control"?: string;
-          /** @description Quoted content digest */
-          ETag?: string;
-          /** @description HTTP timestamp of the upload */
-          "Last-Modified"?: string;
-          /** @description Always `nosniff` */
-          "X-Content-Type-Options"?: string;
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Not Modified */
-      304: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Unknown version */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  changePassword: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ChangePasswordRequest"];
-      };
-    };
-    responses: {
-      /** @description Password changed */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Current password is incorrect */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description API-key authenticated callers cannot change a password */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  login: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["LoginRequest"];
-      };
-    };
-    responses: {
-      /** @description Login successful */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["LoginResponse"];
-        };
-      };
-      /** @description Invalid credentials */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  logout: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Logged out */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  setup: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["SetupRequest"];
-      };
-    };
-    responses: {
-      /** @description Setup complete, session created */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["LoginResponse"];
-        };
-      };
-      /** @description Setup already complete */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getSetupStatus: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Setup status */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SetupStatusResponse"];
-        };
-      };
-    };
-  };
-  listLogs: {
-    parameters: {
-      query?: {
-        /** @description Maximum rows to return. Defaults to 50. */
-        limit?: number;
-        /** @description Cursor from a page's `next_cursor` or `prev_cursor`. */
-        cursor?: string;
-        /** @description Sort direction. Defaults to descending (newest first). */
-        order?: components["schemas"]["OrderParam"];
-        /** @description Only events at this severity or higher. */
-        min_level?: components["schemas"]["LevelResponse"];
-        /**
-         * @description Only events whose target is one of these (comma-separated). Example:
-         *     `aperture,aperture_http`.
-         */
-        target?: string[];
-        /** @description Substring search across message and target. */
-        q?: string;
-        /** @description Only events belonging to this span. */
-        span_id?: components["schemas"]["SpanId"];
-        /** @description Only events from this boot session. */
-        boot_id?: string;
-        /** @description Only events at or after this time (RFC 3339). */
-        since?: string;
-        /** @description Only events at or before this time (RFC 3339). */
-        until?: string;
-        /** @description Structured field filter as a JSON object, e.g. `{"key":"value"}`. */
-        fields?: components["schemas"]["JsonQueryString"];
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Log events */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Page_LogEventResponse"];
-        };
-      };
-    };
-  };
-  listLogBoots: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Boot sessions */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["BootResponse"][];
-        };
-      };
-    };
-  };
-  listSpans: {
-    parameters: {
-      query?: {
-        /** @description Maximum rows to return. Defaults to 50. */
-        limit?: number;
-        /** @description Cursor from a page's `next_cursor` or `prev_cursor`. */
-        cursor?: string;
-        /** @description Sort direction. Defaults to descending (newest first). */
-        order?: components["schemas"]["OrderParam"];
-        /** @description Only spans at this severity or higher. */
-        min_level?: components["schemas"]["LevelResponse"];
-        /**
-         * @description Only spans whose target is one of these (comma-separated). Example:
-         *     `aperture,aperture_storage`.
-         */
-        target?: string[];
-        /** @description Only spans from this boot session. */
-        boot_id?: string;
-        /** @description Only spans started at or after this time (RFC 3339). */
-        since?: string;
-        /** @description Only spans started at or before this time (RFC 3339). */
-        until?: string;
-        /** @description Only direct children of this span id. */
-        parent_id?: components["schemas"]["SpanId"];
-        /** @description When true, only root spans (no parent) are returned. */
-        parent_null?: boolean;
-        /** @description Structured field filter as a JSON object, e.g. `{"key":"value"}`. */
-        fields?: components["schemas"]["JsonQueryString"];
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Spans */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Page_LogSpanResponse"];
-        };
-      };
-    };
-  };
-  getSpan: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Span id */
-        id: components["schemas"]["SpanId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Span with events */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["LogSpanDetailResponse"];
-        };
-      };
-      /** @description Unknown span */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  listLogTargets: {
-    parameters: {
-      query?: {
-        /** @description Only targets starting with this prefix. */
-        q?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Target names */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": string[];
-        };
-      };
-    };
-  };
-  listTaskDefinitions: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Task definitions */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["TaskDefinitionResponse"][];
-        };
-      };
-    };
-  };
-  listTaskSchedules: {
-    parameters: {
-      query?: {
-        limit?: number;
-        cursor?: string;
-        order?: components["schemas"]["OrderParam"];
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Task schedules */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Page_TaskScheduleResponse"];
-        };
-      };
-    };
-  };
-  createTaskSchedule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateTaskScheduleRequest"];
-      };
-    };
-    responses: {
-      /** @description Task schedule created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["TaskScheduleResponse"];
-        };
-      };
-      /** @description Invalid input */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getTaskSchedule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Task schedule id */
-        id: components["schemas"]["TaskScheduleId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Task schedule */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["TaskScheduleResponse"];
-        };
-      };
-      /** @description Unknown task schedule */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  deleteTaskSchedule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Task schedule id */
-        id: components["schemas"]["TaskScheduleId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Task schedule deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Unknown task schedule */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  updateTaskSchedule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Task schedule id */
-        id: components["schemas"]["TaskScheduleId"];
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateTaskScheduleRequest"];
-      };
-    };
-    responses: {
-      /** @description Task schedule updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["TaskScheduleResponse"];
-        };
-      };
-      /** @description Unknown task schedule */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  listTasks: {
-    parameters: {
-      query?: {
-        /** @description Maximum rows to return. Defaults to 50. */
-        limit?: number;
-        /** @description Cursor from a page's `next_cursor` or `prev_cursor`. */
-        cursor?: string;
-        /** @description Sort direction. */
-        order?: components["schemas"]["OrderParam"];
-        /** @description Only tasks in this state, or the `active`/`finished` groups. */
-        status?: components["schemas"]["TaskStatusParam"];
-        /** @description Only tasks of this kind. */
-        kind?: string;
-        /** @description Only children of this task. */
-        parent?: components["schemas"]["TaskId"];
-        /** @description Only top-level tasks (no parent). Ignored when `parent` is set. */
-        root?: boolean;
-        /**
-         * @description Only tasks whose input JSON has `input_value` at this path, for example
-         *     `key` or `source.reference`. Requires `input_value`.
-         */
-        input_path?: string;
-        /** @description The value the field at `input_path` must equal. */
-        input_value?: string;
-        /**
-         * @description Only tasks whose output JSON has `output_value` at this path. Requires
-         *     `output_value`.
-         */
-        output_path?: string;
-        /** @description The value the field at `output_path` must equal. */
-        output_value?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Tasks */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Page_TaskResponse"];
-        };
-      };
-    };
-  };
-  createTask: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateTaskInput"];
-      };
-    };
-    responses: {
-      /** @description Task created */
-      202: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["TaskResponse"];
-        };
-      };
-      /** @description Unknown kind or invalid input */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getTask: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Task id */
-        id: components["schemas"]["TaskId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Task */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["TaskResponse"];
-        };
-      };
-      /** @description Unknown task */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  cancelTask: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Task id */
-        id: components["schemas"]["TaskId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Cancellation requested */
-      202: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Unknown task */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Task kind cannot be cancelled */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Task has already finished */
-      410: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  listUsers: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Users */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["UserResponse"][];
-        };
-      };
-    };
-  };
-  createUser: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateUserRequest"];
-      };
-    };
-    responses: {
-      /** @description User created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["UserResponse"];
-        };
-      };
-      /** @description Insufficient permissions */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getUser: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description User id */
-        id: components["schemas"]["UserId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description User */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["UserResponse"];
-        };
-      };
-      /** @description Unknown user */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  deleteUser: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description User id */
-        id: components["schemas"]["UserId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description User deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Unknown user */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getGatewayVersion: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Gateway version */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["VersionResponse"];
-        };
-      };
-    };
-  };
+    listApiKeys: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description API keys */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiKeyResponse"][];
+                };
+            };
+        };
+    };
+    createApiKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateApiKeyRequest"];
+            };
+        };
+        responses: {
+            /** @description API key created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateApiKeyResponse"];
+                };
+            };
+        };
+    };
+    deleteApiKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description API key id */
+                id: components["schemas"]["ApiKeyId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description API key deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unknown API key */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listArtifacts: {
+        parameters: {
+            query?: {
+                /** @description Maximum rows to return. Defaults to 50. */
+                limit?: number;
+                /** @description Cursor from a page's `next_cursor` or `prev_cursor`. */
+                cursor?: string;
+                /** @description Sort direction. */
+                order?: components["schemas"]["OrderParam"];
+                /** @description Match keys containing this substring. */
+                q?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Artifacts */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Page_ArtifactSummaryResponse"];
+                };
+            };
+        };
+    };
+    getArtifact: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Artifact key */
+                key: components["schemas"]["ArtifactKey"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Artifact */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArtifactSummaryResponse"];
+                };
+            };
+            /** @description Unknown artifact */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    uploadArtifact: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Artifact key */
+                key: components["schemas"]["ArtifactKey"];
+            };
+            cookie?: never;
+        };
+        /** @description Raw artifact bytes to store */
+        requestBody?: {
+            content: {
+                "application/octet-stream": unknown;
+            };
+        };
+        responses: {
+            /** @description Version stored */
+            201: {
+                headers: {
+                    /** @description Path to the newly stored version */
+                    Location?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArtifactVersionResponse"];
+                };
+            };
+            /** @description Body exceeded the maximum upload size */
+            413: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listArtifactVersions: {
+        parameters: {
+            query?: {
+                /** @description Maximum rows to return. Defaults to 50. */
+                limit?: number;
+                /** @description Cursor from a page's `next_cursor` or `prev_cursor`. */
+                cursor?: string;
+                /** @description Sort direction. */
+                order?: components["schemas"]["OrderParam"];
+                /** @description Field to sort by. Defaults to downloaded time. */
+                sort?: components["schemas"]["VersionSortParam"];
+                /** @description Only versions with this exact media type. */
+                media_type?: components["schemas"]["MediaType"];
+                /** @description Only versions with this exact version string. */
+                version?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Artifact key */
+                key: components["schemas"]["ArtifactKey"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Versions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Page_ArtifactVersionResponse"];
+                };
+            };
+        };
+    };
+    getArtifactVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Artifact key */
+                key: components["schemas"]["ArtifactKey"];
+                /** @description Content digest */
+                digest: components["schemas"]["Digest"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Version */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArtifactVersionResponse"];
+                };
+            };
+            /** @description Unknown version */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteArtifactVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Artifact key */
+                key: components["schemas"]["ArtifactKey"];
+                /** @description Content digest */
+                digest: components["schemas"]["Digest"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Version evicted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unknown version */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    downloadArtifactBlob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Artifact key */
+                key: components["schemas"]["ArtifactKey"];
+                /** @description Content digest */
+                digest: components["schemas"]["Digest"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Blob content */
+            200: {
+                headers: {
+                    /** @description Immutable caching directive */
+                    "Cache-Control"?: string;
+                    /** @description Quoted content digest */
+                    ETag?: string;
+                    /** @description HTTP timestamp of the upload */
+                    "Last-Modified"?: string;
+                    /** @description Always `nosniff` */
+                    "X-Content-Type-Options"?: string;
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not Modified */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unknown version */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    changePassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChangePasswordRequest"];
+            };
+        };
+        responses: {
+            /** @description Password changed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Current password is incorrect */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description API-key authenticated callers cannot change a password */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    login: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LoginRequest"];
+            };
+        };
+        responses: {
+            /** @description Login successful */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LoginResponse"];
+                };
+            };
+            /** @description Invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    logout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Logged out */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getCurrentUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current caller */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CurrentUserResponse"];
+                };
+            };
+        };
+    };
+    setup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetupRequest"];
+            };
+        };
+        responses: {
+            /** @description Setup complete, session created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LoginResponse"];
+                };
+            };
+            /** @description Setup already complete */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getSetupStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Setup status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetupStatusResponse"];
+                };
+            };
+        };
+    };
+    listLogs: {
+        parameters: {
+            query?: {
+                /** @description Maximum rows to return. Defaults to 50. */
+                limit?: number;
+                /** @description Cursor from a page's `next_cursor` or `prev_cursor`. */
+                cursor?: string;
+                /** @description Sort direction. Defaults to descending (newest first). */
+                order?: components["schemas"]["OrderParam"];
+                /** @description Only events at this severity or higher. */
+                min_level?: components["schemas"]["LevelResponse"];
+                /**
+                 * @description Only events whose target is one of these (comma-separated). Example:
+                 *     `aperture,aperture_http`.
+                 */
+                target?: string[];
+                /** @description Substring search across message and target. */
+                q?: string;
+                /** @description Only events belonging to this span. */
+                span_id?: components["schemas"]["SpanId"];
+                /** @description Only events from this boot session. */
+                boot_id?: string;
+                /** @description Only events at or after this time (RFC 3339). */
+                since?: string;
+                /** @description Only events at or before this time (RFC 3339). */
+                until?: string;
+                /** @description Structured field filter as a JSON object, e.g. `{"key":"value"}`. */
+                fields?: components["schemas"]["JsonQueryString"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Log events */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Page_LogEventResponse"];
+                };
+            };
+        };
+    };
+    listLogBoots: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Boot sessions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BootResponse"][];
+                };
+            };
+        };
+    };
+    listSpans: {
+        parameters: {
+            query?: {
+                /** @description Maximum rows to return. Defaults to 50. */
+                limit?: number;
+                /** @description Cursor from a page's `next_cursor` or `prev_cursor`. */
+                cursor?: string;
+                /** @description Sort direction. Defaults to descending (newest first). */
+                order?: components["schemas"]["OrderParam"];
+                /** @description Only spans at this severity or higher. */
+                min_level?: components["schemas"]["LevelResponse"];
+                /**
+                 * @description Only spans whose target is one of these (comma-separated). Example:
+                 *     `aperture,aperture_storage`.
+                 */
+                target?: string[];
+                /** @description Only spans from this boot session. */
+                boot_id?: string;
+                /** @description Only spans started at or after this time (RFC 3339). */
+                since?: string;
+                /** @description Only spans started at or before this time (RFC 3339). */
+                until?: string;
+                /** @description Only direct children of this span id. */
+                parent_id?: components["schemas"]["SpanId"];
+                /** @description When true, only root spans (no parent) are returned. */
+                parent_null?: boolean;
+                /** @description Structured field filter as a JSON object, e.g. `{"key":"value"}`. */
+                fields?: components["schemas"]["JsonQueryString"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Spans */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Page_LogSpanResponse"];
+                };
+            };
+        };
+    };
+    getSpan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Span id */
+                id: components["schemas"]["SpanId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Span with events */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogSpanDetailResponse"];
+                };
+            };
+            /** @description Unknown span */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listLogTargets: {
+        parameters: {
+            query?: {
+                /** @description Only targets starting with this prefix. */
+                q?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Target names */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string[];
+                };
+            };
+        };
+    };
+    listTaskDefinitions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Task definitions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskDefinitionResponse"][];
+                };
+            };
+        };
+    };
+    listTaskSchedules: {
+        parameters: {
+            query?: {
+                limit?: number;
+                cursor?: string;
+                order?: components["schemas"]["OrderParam"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Task schedules */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Page_TaskScheduleResponse"];
+                };
+            };
+        };
+    };
+    createTaskSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateTaskScheduleRequest"];
+            };
+        };
+        responses: {
+            /** @description Task schedule created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskScheduleResponse"];
+                };
+            };
+            /** @description Invalid input */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getTaskSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Task schedule id */
+                id: components["schemas"]["TaskScheduleId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Task schedule */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskScheduleResponse"];
+                };
+            };
+            /** @description Unknown task schedule */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteTaskSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Task schedule id */
+                id: components["schemas"]["TaskScheduleId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Task schedule deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unknown task schedule */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    updateTaskSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Task schedule id */
+                id: components["schemas"]["TaskScheduleId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateTaskScheduleRequest"];
+            };
+        };
+        responses: {
+            /** @description Task schedule updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskScheduleResponse"];
+                };
+            };
+            /** @description Unknown task schedule */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listTasks: {
+        parameters: {
+            query?: {
+                /** @description Maximum rows to return. Defaults to 50. */
+                limit?: number;
+                /** @description Cursor from a page's `next_cursor` or `prev_cursor`. */
+                cursor?: string;
+                /** @description Sort direction. */
+                order?: components["schemas"]["OrderParam"];
+                /** @description Only tasks in this state, or the `active`/`finished` groups. */
+                status?: components["schemas"]["TaskStatusParam"];
+                /** @description Only tasks of this kind. */
+                kind?: string;
+                /** @description Only children of this task. */
+                parent?: components["schemas"]["TaskId"];
+                /** @description Only top-level tasks (no parent). Ignored when `parent` is set. */
+                root?: boolean;
+                /**
+                 * @description Only tasks whose input JSON has `input_value` at this path, for example
+                 *     `key` or `source.reference`. Requires `input_value`.
+                 */
+                input_path?: string;
+                /** @description The value the field at `input_path` must equal. */
+                input_value?: string;
+                /**
+                 * @description Only tasks whose output JSON has `output_value` at this path. Requires
+                 *     `output_value`.
+                 */
+                output_path?: string;
+                /** @description The value the field at `output_path` must equal. */
+                output_value?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Tasks */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Page_TaskResponse"];
+                };
+            };
+        };
+    };
+    createTask: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateTaskInput"];
+            };
+        };
+        responses: {
+            /** @description Task created */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskResponse"];
+                };
+            };
+            /** @description Unknown kind or invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getTask: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Task id */
+                id: components["schemas"]["TaskId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Task */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskResponse"];
+                };
+            };
+            /** @description Unknown task */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    cancelTask: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Task id */
+                id: components["schemas"]["TaskId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Cancellation requested */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unknown task */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Task kind cannot be cancelled */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Task has already finished */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listUsers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Users */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserResponse"][];
+                };
+            };
+        };
+    };
+    createUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateUserRequest"];
+            };
+        };
+        responses: {
+            /** @description User created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserResponse"];
+                };
+            };
+            /** @description Insufficient permissions */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User id */
+                id: components["schemas"]["UserId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description User */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserResponse"];
+                };
+            };
+            /** @description Unknown user */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User id */
+                id: components["schemas"]["UserId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description User deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unknown user */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getGatewayVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Gateway version */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VersionResponse"];
+                };
+            };
+        };
+    };
 }

--- a/modules/aperture/runtime/generated.ts
+++ b/modules/aperture/runtime/generated.ts
@@ -490,10 +490,18 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * @description Primary key of a row in the `actors` table.
+         *
+         *     Used wherever an actor is referenced: `users.actor_id`,
+         *     `sessions.actor_id`, `api_keys.actor_id`, `tasks.initiator_id`.
+         */
+        ActorId: string;
         /** @description Primary key of a row in the `api_keys` table. */
         ApiKeyId: string;
         ApiKeyResponse: {
-            id: string;
+            id: components["schemas"]["ApiKeyId"];
+            /** Format: date-time */
             last_used_at?: string | null;
             name: string;
             prefix: string;
@@ -593,7 +601,7 @@ export interface components {
             role?: null | components["schemas"]["Role"];
         };
         CreateApiKeyResponse: {
-            id: string;
+            id: components["schemas"]["ApiKeyId"];
             /** @description The full key. Only visible at creation time. */
             key: components["schemas"]["RawApiKey"];
             name: string;
@@ -627,10 +635,10 @@ export interface components {
             username: components["schemas"]["Username"];
         };
         CurrentUserResponse: {
-            actor_id: string;
+            actor_id: components["schemas"]["ActorId"];
             display_name: string;
             must_change_password: boolean;
-            role?: null | components["schemas"]["Role"];
+            roles: components["schemas"]["Role"][];
             username?: string | null;
         };
         /** @description Content digest, e.g. `sha256:hex`. */
@@ -1120,8 +1128,8 @@ export interface components {
         /** @description Primary key of a row in the `users` table. */
         UserId: string;
         UserResponse: {
-            actor_id: string;
-            id: string;
+            actor_id: components["schemas"]["ActorId"];
+            id: components["schemas"]["UserId"];
             must_change_password: boolean;
             username: string;
         };

--- a/modules/aperture/runtime/plugins/auth.client.ts
+++ b/modules/aperture/runtime/plugins/auth.client.ts
@@ -1,0 +1,11 @@
+export default defineNuxtPlugin(() => {
+  setUnauthorizedHandler(() => {
+    const { user } = useAuth();
+    if (user.value === null) {
+      return;
+    }
+    user.value = null;
+    const localePath = useLocalePath();
+    navigateTo(localePath("/login"));
+  });
+});

--- a/modules/aperture/runtime/types.ts
+++ b/modules/aperture/runtime/types.ts
@@ -40,3 +40,12 @@ export type BootList = BootResponse[];
 export type ListLogsParams = NonNullable<operations["listLogs"]["parameters"]["query"]>;
 export type ListLogSpansParams = NonNullable<operations["listSpans"]["parameters"]["query"]>;
 export type ListLogTargetsParams = NonNullable<operations["listLogTargets"]["parameters"]["query"]>;
+
+export type Role = Schemas["Role"];
+export type CurrentUser = Schemas["CurrentUserResponse"];
+export type SetupStatus = Schemas["SetupStatusResponse"];
+export type LoginResponse = Schemas["LoginResponse"];
+
+export type LoginBody = Schemas["LoginRequest"];
+export type SetupBody = Schemas["SetupRequest"];
+export type ChangePasswordBody = Schemas["ChangePasswordRequest"];

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 import * as z from "zod/v4/mini";
-import {
-  changePasswordSchema,
-  loginSchema,
-  PASSWORD_MIN,
-  setupSchema,
-} from "~/utils/auth";
+import { changePasswordSchema, loginSchema, PASSWORD_MIN, setupSchema } from "~/utils/auth";
 
 function ok(schema: z.core.$ZodType, data: unknown): boolean {
   return z.safeParse(schema, data).success;

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import * as z from "zod/v4/mini";
+import {
+  changePasswordSchema,
+  loginSchema,
+  PASSWORD_MIN,
+  setupSchema,
+} from "~/utils/auth";
+
+function ok(schema: z.core.$ZodType, data: unknown): boolean {
+  return z.safeParse(schema, data).success;
+}
+
+describe("loginSchema", () => {
+  it("accepts non-empty username and password", () => {
+    expect(ok(loginSchema, { username: "alice", password: "secret123456" })).toBe(true);
+  });
+
+  it("rejects empty fields", () => {
+    expect(ok(loginSchema, { username: "", password: "x" })).toBe(false);
+    expect(ok(loginSchema, { username: "a", password: "" })).toBe(false);
+  });
+});
+
+describe("setupSchema", () => {
+  const valid = { username: "admin", password: "secure-pass-1", confirmPassword: "secure-pass-1" };
+
+  it("accepts a valid admin with matching passwords", () => {
+    expect(ok(setupSchema, valid)).toBe(true);
+  });
+
+  it("enforces the password minimum length", () => {
+    expect(ok(setupSchema, { ...valid, password: "x".repeat(PASSWORD_MIN - 1) })).toBe(false);
+  });
+
+  it("rejects invalid username characters", () => {
+    expect(ok(setupSchema, { ...valid, username: "bad name" })).toBe(false);
+    expect(ok(setupSchema, { ...valid, username: "ünicode" })).toBe(false);
+  });
+});
+
+describe("changePasswordSchema", () => {
+  const valid = {
+    currentPassword: "old-password-1",
+    newPassword: "new-password-1",
+    confirmPassword: "new-password-1",
+  };
+
+  it("accepts a valid change", () => {
+    expect(ok(changePasswordSchema, valid)).toBe(true);
+  });
+
+  it("requires all fields", () => {
+    expect(ok(changePasswordSchema, { ...valid, currentPassword: "" })).toBe(false);
+  });
+});


### PR DESCRIPTION
Depends on stargrid-systems/aperture#171 for the `/auth/me` endpoint that the session probe uses. The regenerated spec and types here already include it.

Covers the auth flow only: session probe via `/auth/me`, global route protection (setup/login/change-password redirects), 401 handling, and the login, setup, and forced change-password pages. Management UI (users, API keys, account) is in a follow-up stacked on this branch.