### PR TITLE
chore: sync aperture API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,13 @@ npm run test:watch # Run vitest in watch mode
 ### API code generation
 
 Spectra consumes aperture's OpenAPI spec to generate TypeScript types for the
-API layer. The spec lives at `openapi/openapi.json` and the generated types at
-`app/utils/api/generated.ts`.
+API layer. The spec lives at `modules/aperture/openapi.json` and the generated
+types at `modules/aperture/runtime/generated.ts`.
 
 To regenerate after aperture changes:
 
-1. From the aperture directory: `cargo run -- openapi > ../spectra/openapi/openapi.json`
+1. From the aperture directory: `cargo run -- openapi > ../spectra/modules/aperture/openapi.json`
 2. From the spectra directory: `npm run openapi:generate`
-
-The generation script patches the spec with missing enum schemas and resolves
-a duplicate operation ID. See `scripts/patch-openapi.mjs`.
 
 ### Production build
 

--- a/modules/aperture/openapi.json
+++ b/modules/aperture/openapi.json
@@ -18,16 +18,43 @@
       "get": {
         "summary": "Lists API keys for the authenticated actor.",
         "operationId": "listApiKeys",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrderParam"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "API keys",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ApiKeyResponse"
-                  }
+                  "$ref": "#/components/schemas/Page_ApiKeyResponse"
                 }
               }
             }
@@ -724,16 +751,43 @@
       "get": {
         "summary": "Lists distinct boot sessions, newest first.",
         "operationId": "listLogBoots",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrderParam"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Boot sessions",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/BootResponse"
-                  }
+                  "$ref": "#/components/schemas/Page_BootResponse"
                 }
               }
             }
@@ -915,6 +969,34 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrderParam"
+            }
           }
         ],
         "responses": {
@@ -923,13 +1005,106 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "$ref": "#/components/schemas/Page_String"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/settings": {
+      "get": {
+        "summary": "Lists every setting key with its current value.",
+        "operationId": "listSettings",
+        "responses": {
+          "200": {
+            "description": "Settings",
+            "content": {
+              "application/json": {
+                "schema": {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "$ref": "#/components/schemas/SettingResponse"
                   }
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/v1/settings/{key}": {
+      "get": {
+        "summary": "Returns the value of one setting key.",
+        "operationId": "getSetting",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "Setting key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Setting value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SettingResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown setting key"
+          }
+        }
+      },
+      "put": {
+        "summary": "Replaces the value of one setting key.",
+        "operationId": "updateSetting",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "Setting key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSettingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Setting updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SettingResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid value"
+          },
+          "404": {
+            "description": "Unknown setting key"
           }
         }
       }
@@ -1347,16 +1522,43 @@
       "get": {
         "summary": "Lists all users.",
         "operationId": "listUsers",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrderParam"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Users",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UserResponse"
-                  }
+                  "$ref": "#/components/schemas/Page_UserResponse"
                 }
               }
             }
@@ -2176,6 +2378,59 @@
           "desc"
         ]
       },
+      "Page_ApiKeyResponse": {
+        "type": "object",
+        "description": "A page of results plus the cursors for the neighbouring pages.",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "name",
+                "prefix"
+              ],
+              "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/ApiKeyId"
+                },
+                "last_used_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "prefix": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The rows in this page."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Cursor to pass as `?cursor=` for the next page. Null at the end."
+          },
+          "prev_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Cursor to pass as `?cursor=` for the previous page. Null at the start."
+          }
+        }
+      },
       "Page_ArtifactSummaryResponse": {
         "type": "object",
         "description": "A page of results plus the cursors for the neighbouring pages.",
@@ -2321,6 +2576,71 @@
                     "null"
                   ],
                   "description": "Human-readable version, if known."
+                }
+              }
+            },
+            "description": "The rows in this page."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Cursor to pass as `?cursor=` for the next page. Null at the end."
+          },
+          "prev_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Cursor to pass as `?cursor=` for the previous page. Null at the start."
+          }
+        }
+      },
+      "Page_BootResponse": {
+        "type": "object",
+        "description": "A page of results plus the cursors for the neighbouring pages.",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "One boot session observed in the log store, returned by\n`GET /api/v1/logs/boots`.",
+              "required": [
+                "boot_id",
+                "first_seen",
+                "last_seen",
+                "event_count",
+                "is_current"
+              ],
+              "properties": {
+                "boot_id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Unique boot id (UUID)."
+                },
+                "event_count": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "Number of events recorded so far in this boot.",
+                  "minimum": 0
+                },
+                "first_seen": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Timestamp of the earliest event in this boot."
+                },
+                "is_current": {
+                  "type": "boolean",
+                  "description": "True if this is the currently running gateway boot."
+                },
+                "last_seen": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Timestamp of the latest event in this boot."
                 }
               }
             },
@@ -2552,6 +2872,36 @@
           }
         }
       },
+      "Page_String": {
+        "type": "object",
+        "description": "A page of results plus the cursors for the neighbouring pages.",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The rows in this page."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Cursor to pass as `?cursor=` for the next page. Null at the end."
+          },
+          "prev_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Cursor to pass as `?cursor=` for the previous page. Null at the start."
+          }
+        }
+      },
       "Page_TaskResponse": {
         "type": "object",
         "description": "A page of results plus the cursors for the neighbouring pages.",
@@ -2739,6 +3089,56 @@
           }
         }
       },
+      "Page_UserResponse": {
+        "type": "object",
+        "description": "A page of results plus the cursors for the neighbouring pages.",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "actor_id",
+                "username",
+                "must_change_password"
+              ],
+              "properties": {
+                "actor_id": {
+                  "$ref": "#/components/schemas/ActorId"
+                },
+                "id": {
+                  "$ref": "#/components/schemas/UserId"
+                },
+                "must_change_password": {
+                  "type": "boolean"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The rows in this page."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Cursor to pass as `?cursor=` for the next page. Null at the end."
+          },
+          "prev_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Cursor to pass as `?cursor=` for the previous page. Null at the start."
+          }
+        }
+      },
       "Password": {
         "type": "string",
         "description": "A plaintext password. Redacts in Debug output to avoid accidental leakage.\n\nUnlike [`Username`](crate::Username), `Password` does NOT validate on\nconstruction or deserialization. This is deliberate: the login handler must\naccept any password string (even one below the minimum length) so the\nrequest reaches the handler body where the rate limiter is consulted.\nValidating at deserialization would let an attacker bypass rate limiting\nby sending short passwords (they would be rejected with a 400 before the\nhandler runs). Password validation happens in\n[`AuthHandle`](crate::AuthHandle) methods (`create_user`,\n`change_password`, `setup_admin`) instead."
@@ -2829,6 +3229,20 @@
             "type": "boolean",
             "description": "Whether the leaf was actually re-issued."
           }
+        }
+      },
+      "SettingResponse": {
+        "type": "object",
+        "description": "One setting key and its current value.",
+        "required": [
+          "key",
+          "value"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {}
         }
       },
       "SetupRequest": {
@@ -3058,6 +3472,16 @@
           "cancelled",
           "interrupted"
         ]
+      },
+      "UpdateSettingRequest": {
+        "type": "object",
+        "description": "Body for `PUT /api/v1/settings/{key}`.",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {}
+        }
       },
       "UpdateTaskScheduleRequest": {
         "type": "object",

--- a/modules/aperture/runtime/client.ts
+++ b/modules/aperture/runtime/client.ts
@@ -42,6 +42,10 @@ export class ApiError extends Error {
   }
 }
 
+// Several list endpoints are now paginated on the server but are consumed as
+// plain arrays here. Request the largest page until the UI supports cursors.
+const LIST_LIMIT = 200;
+
 const AUTH_ENDPOINTS = new Set([
   "/api/v1/auth/me",
   "/api/v1/auth/login",
@@ -124,10 +128,16 @@ export const apertureApi = {
   },
 
   listLogTargets: async (params?: ListLogTargetsParams): Promise<string[]> =>
-    unwrap(await client.GET("/api/v1/logs/targets", { params: { query: params } })),
+    unwrap(
+      await client.GET("/api/v1/logs/targets", {
+        params: { query: { limit: LIST_LIMIT, ...params } },
+      }),
+    ).items,
 
   listLogBoots: async (): Promise<BootList> =>
-    unwrap(await client.GET("/api/v1/logs/boots")).map(toBootResponse),
+    unwrap(
+      await client.GET("/api/v1/logs/boots", { params: { query: { limit: LIST_LIMIT } } }),
+    ).items.map(toBootResponse),
 
   listSpans: async (params?: ListLogSpansParams): Promise<LogSpanPage> => {
     const data = unwrap(await client.GET("/api/v1/logs/spans", { params: { query: params } }));
@@ -158,7 +168,8 @@ export const apertureApi = {
     unwrapVoid(await client.POST("/api/v1/auth/change-password", { body }));
   },
 
-  listUsers: async (): Promise<User[]> => unwrap(await client.GET("/api/v1/users")),
+  listUsers: async (): Promise<User[]> =>
+    unwrap(await client.GET("/api/v1/users", { params: { query: { limit: LIST_LIMIT } } })).items,
 
   createUser: async (body: CreateUserBody): Promise<User> =>
     unwrap(await client.POST("/api/v1/users", { body })),
@@ -167,7 +178,9 @@ export const apertureApi = {
     unwrapVoid(await client.DELETE("/api/v1/users/{id}", { params: { path: { id } } }));
   },
 
-  listApiKeys: async (): Promise<ApiKey[]> => unwrap(await client.GET("/api/v1/api-keys")),
+  listApiKeys: async (): Promise<ApiKey[]> =>
+    unwrap(await client.GET("/api/v1/api-keys", { params: { query: { limit: LIST_LIMIT } } }))
+      .items,
 
   createApiKey: async (body: CreateApiKeyBody): Promise<CreatedApiKey> =>
     unwrap(await client.POST("/api/v1/api-keys", { body })),

--- a/modules/aperture/runtime/generated.ts
+++ b/modules/aperture/runtime/generated.ts
@@ -321,6 +321,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lists every setting key with its current value. */
+        get: operations["listSettings"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/settings/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns the value of one setting key. */
+        get: operations["getSetting"];
+        /** Replaces the value of one setting key. */
+        put: operations["updateSetting"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/task-definitions": {
         parameters: {
             query?: never;
@@ -781,6 +816,21 @@ export interface components {
          */
         OrderParam: "asc" | "desc";
         /** @description A page of results plus the cursors for the neighbouring pages. */
+        Page_ApiKeyResponse: {
+            /** @description The rows in this page. */
+            items: {
+                id: components["schemas"]["ApiKeyId"];
+                /** Format: date-time */
+                last_used_at?: string | null;
+                name: string;
+                prefix: string;
+            }[];
+            /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
+            next_cursor?: string | null;
+            /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
+            prev_cursor?: string | null;
+        };
+        /** @description A page of results plus the cursors for the neighbouring pages. */
         Page_ArtifactSummaryResponse: {
             /** @description The rows in this page. */
             items: {
@@ -841,6 +891,38 @@ export interface components {
                 verified_at?: string | null;
                 /** @description Human-readable version, if known. */
                 version?: string | null;
+            }[];
+            /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
+            next_cursor?: string | null;
+            /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
+            prev_cursor?: string | null;
+        };
+        /** @description A page of results plus the cursors for the neighbouring pages. */
+        Page_BootResponse: {
+            /** @description The rows in this page. */
+            items: {
+                /**
+                 * Format: uuid
+                 * @description Unique boot id (UUID).
+                 */
+                boot_id: string;
+                /**
+                 * Format: int64
+                 * @description Number of events recorded so far in this boot.
+                 */
+                event_count: number;
+                /**
+                 * Format: date-time
+                 * @description Timestamp of the earliest event in this boot.
+                 */
+                first_seen: string;
+                /** @description True if this is the currently running gateway boot. */
+                is_current: boolean;
+                /**
+                 * Format: date-time
+                 * @description Timestamp of the latest event in this boot.
+                 */
+                last_seen: string;
             }[];
             /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
             next_cursor?: string | null;
@@ -928,6 +1010,15 @@ export interface components {
             prev_cursor?: string | null;
         };
         /** @description A page of results plus the cursors for the neighbouring pages. */
+        Page_String: {
+            /** @description The rows in this page. */
+            items: string[];
+            /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
+            next_cursor?: string | null;
+            /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
+            prev_cursor?: string | null;
+        };
+        /** @description A page of results plus the cursors for the neighbouring pages. */
         Page_TaskResponse: {
             /** @description The rows in this page. */
             items: {
@@ -988,6 +1079,20 @@ export interface components {
             /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
             prev_cursor?: string | null;
         };
+        /** @description A page of results plus the cursors for the neighbouring pages. */
+        Page_UserResponse: {
+            /** @description The rows in this page. */
+            items: {
+                actor_id: components["schemas"]["ActorId"];
+                id: components["schemas"]["UserId"];
+                must_change_password: boolean;
+                username: string;
+            }[];
+            /** @description Cursor to pass as `?cursor=` for the next page. Null at the end. */
+            next_cursor?: string | null;
+            /** @description Cursor to pass as `?cursor=` for the previous page. Null at the start. */
+            prev_cursor?: string | null;
+        };
         /**
          * @description A plaintext password. Redacts in Debug output to avoid accidental leakage.
          *
@@ -1037,6 +1142,11 @@ export interface components {
         RotateCertificateOutput: {
             /** @description Whether the leaf was actually re-issued. */
             rotated: boolean;
+        };
+        /** @description One setting key and its current value. */
+        SettingResponse: {
+            key: string;
+            value: unknown;
         };
         SetupRequest: {
             password: components["schemas"]["Password"];
@@ -1120,6 +1230,10 @@ export interface components {
          * @enum {string}
          */
         TaskStatusResponse: "pending" | "running" | "succeeded" | "failed" | "cancelled" | "interrupted";
+        /** @description Body for `PUT /api/v1/settings/{key}`. */
+        UpdateSettingRequest: {
+            value: unknown;
+        };
         /** @description Body for `PATCH /api/v1/task-schedules/{id}`. */
         UpdateTaskScheduleRequest: {
             enabled?: boolean | null;
@@ -1168,7 +1282,11 @@ export type $defs = Record<string, never>;
 export interface operations {
     listApiKeys: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                cursor?: string;
+                order?: components["schemas"]["OrderParam"];
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -1181,7 +1299,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ApiKeyResponse"][];
+                    "application/json": components["schemas"]["Page_ApiKeyResponse"];
                 };
             };
         };
@@ -1681,7 +1799,11 @@ export interface operations {
     };
     listLogBoots: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                cursor?: string;
+                order?: components["schemas"]["OrderParam"];
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -1694,7 +1816,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["BootResponse"][];
+                    "application/json": components["schemas"]["Page_BootResponse"];
                 };
             };
         };
@@ -1780,6 +1902,9 @@ export interface operations {
             query?: {
                 /** @description Only targets starting with this prefix. */
                 q?: string;
+                limit?: number;
+                cursor?: string;
+                order?: components["schemas"]["OrderParam"];
             };
             header?: never;
             path?: never;
@@ -1793,8 +1918,99 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": string[];
+                    "application/json": components["schemas"]["Page_String"];
                 };
+            };
+        };
+    };
+    listSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Settings */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SettingResponse"][];
+                };
+            };
+        };
+    };
+    getSetting: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Setting key */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Setting value */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SettingResponse"];
+                };
+            };
+            /** @description Unknown setting key */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    updateSetting: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Setting key */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateSettingRequest"];
+            };
+        };
+        responses: {
+            /** @description Setting updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SettingResponse"];
+                };
+            };
+            /** @description Invalid value */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unknown setting key */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -2119,7 +2335,11 @@ export interface operations {
     };
     listUsers: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                cursor?: string;
+                order?: components["schemas"]["OrderParam"];
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -2132,7 +2352,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UserResponse"][];
+                    "application/json": components["schemas"]["Page_UserResponse"];
                 };
             };
         };


### PR DESCRIPTION
Regenerates the OpenAPI spec and types. listLogTargets, listLogBoots, listUsers, and listApiKeys are now paginated on the server. The client unwraps the page and requests the largest page size (200) until the UI supports cursor pagination.

Also fixes the stale regeneration steps in the README.