### PR TITLE
fix: show eCube logo on auth layout

### DIFF
--- a/app/layouts/auth.vue
+++ b/app/layouts/auth.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="min-h-screen flex flex-col items-center justify-center gap-8 p-4">
     <div class="flex flex-col items-center gap-1 text-center">
-      <UIcon name="i-lucide-grid-3x3" class="size-10 text-primary" />
+      <img src="/favicon.svg" alt="" class="h-10 w-10" />
       <h1 class="text-xl font-semibold">{{ $t("app.name") }}</h1>
       <p class="text-muted text-sm">{{ $t("app.description") }}</p>
     </div>


### PR DESCRIPTION
The auth layout used a generic grid icon instead of the brand mark. Uses /favicon.svg, so land after #235 for the v2 look.

The mark is dark navy on a transparent background, so it reads low-contrast in dark mode. Worth a visual check.