### PR TITLE
fix: show password requirements on auth forms

### DIFF
--- a/app/components/PasswordRequirements.vue
+++ b/app/components/PasswordRequirements.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { PASSWORD_MIN, passwordRequirements } from "~/utils/auth";
+
+const props = defineProps<{ value: string }>();
+const { t } = useI18n();
+
+const items = computed(() =>
+  passwordRequirements(props.value).map((rule) => ({
+    key: rule.key,
+    satisfied: rule.satisfied,
+    label: t(`auth.passwordRequirements.${rule.key}`, { n: PASSWORD_MIN }),
+  })),
+);
+</script>
+
+<template>
+  <ul class="flex flex-col gap-1 mt-2 text-sm">
+    <li
+      v-for="item in items"
+      :key="item.key"
+      class="flex items-center gap-1.5"
+      :class="item.satisfied ? 'text-success' : 'text-muted-foreground'"
+    >
+      <UIcon :name="item.satisfied ? 'i-lucide-circle-check' : 'i-lucide-circle'" class="size-4" />
+      <span>{{ item.label }}</span>
+    </li>
+  </ul>
+</template>

--- a/app/pages/change-password.vue
+++ b/app/pages/change-password.vue
@@ -70,6 +70,7 @@ async function onSubmit(event: FormSubmitEvent<ChangePasswordValues>) {
           autocomplete="new-password"
           class="w-full"
         />
+        <PasswordRequirements :value="state.newPassword" />
       </UFormField>
 
       <UFormField :label="$t('auth.changePassword.confirm')" name="confirmPassword">

--- a/app/pages/settings/users.vue
+++ b/app/pages/settings/users.vue
@@ -109,6 +109,7 @@ async function onDelete(target: User) {
               autocomplete="new-password"
               class="w-full"
             />
+            <PasswordRequirements :value="createState.password" />
           </UFormField>
 
           <UFormField :label="$t('auth.users.role')" name="role">

--- a/app/pages/setup.vue
+++ b/app/pages/setup.vue
@@ -55,6 +55,7 @@ async function onSubmit(event: FormSubmitEvent<SetupValues>) {
           autocomplete="new-password"
           class="w-full"
         />
+        <PasswordRequirements :value="state.password" />
       </UFormField>
 
       <UFormField :label="$t('auth.setup.confirmPassword')" name="confirmPassword">

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -5,6 +5,19 @@ export const USERNAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 export const PASSWORD_MIN = 12;
 export const PASSWORD_MAX = 1024;
 
+export interface PasswordRequirement {
+  key: string;
+  satisfied: boolean;
+}
+
+export const PASSWORD_RULES = [
+  { key: "minLength", test: (v: string) => v.length >= PASSWORD_MIN },
+] as const;
+
+export function passwordRequirements(value: string): PasswordRequirement[] {
+  return PASSWORD_RULES.map((rule) => ({ key: rule.key, satisfied: rule.test(value) }));
+}
+
 const requiredString = z.string().check(z.minLength(1));
 const usernameField = z.string().check(z.minLength(1), z.maxLength(64), z.regex(USERNAME_PATTERN));
 const newPasswordField = z.string().check(z.minLength(PASSWORD_MIN), z.maxLength(PASSWORD_MAX));

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -41,6 +41,9 @@
       "failed": "Einrichtung fehlgeschlagen.",
       "passwordsMismatch": "Passwörter stimmen nicht überein."
     },
+    "passwordRequirements": {
+      "minLength": "Mindestens {n} Zeichen"
+    },
     "changePassword": {
       "title": "Passwort ändern",
       "subtitle": "Wähle ein neues Passwort, bevor du fortfährst.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -41,6 +41,9 @@
       "failed": "Setup failed.",
       "passwordsMismatch": "Passwords do not match."
     },
+    "passwordRequirements": {
+      "minLength": "At least {n} characters"
+    },
     "changePassword": {
       "title": "Change password",
       "subtitle": "Choose a new password before continuing.",

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -7,6 +7,7 @@ import {
   isRole,
   loginSchema,
   PASSWORD_MIN,
+  passwordRequirements,
   setupSchema,
 } from "~/utils/auth";
 
@@ -90,5 +91,23 @@ describe("isRole", () => {
     expect(isRole("operator")).toBe(true);
     expect(isRole("viewer")).toBe(true);
     expect(isRole("superuser")).toBe(false);
+  });
+});
+
+describe("passwordRequirements", () => {
+  it("marks the minimum length unmet below the threshold", () => {
+    const result = passwordRequirements("x".repeat(PASSWORD_MIN - 1));
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("minLength");
+    expect(result[0].satisfied).toBe(false);
+  });
+
+  it("marks the minimum length met at and above the threshold", () => {
+    expect(passwordRequirements("x".repeat(PASSWORD_MIN))[0].satisfied).toBe(true);
+    expect(passwordRequirements("x".repeat(PASSWORD_MIN + 10))[0].satisfied).toBe(true);
+  });
+
+  it("treats the empty password as unmet", () => {
+    expect(passwordRequirements("")[0].satisfied).toBe(false);
   });
 });


### PR DESCRIPTION
Adds a live requirements indicator below the password field on setup, change-password, and the create-user modal. Aperture only enforces a 12-character minimum, so the checklist has a single rule that turns green once met.