### PR TITLE
feat: show per-user constellation avatars

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -6,6 +6,12 @@ const { t } = useI18n();
 const localePath = useLocalePath();
 const { user, logout } = useAuth();
 
+const avatarUrl = computed(() => {
+  const id = user.value?.user_id;
+  return id ? userAvatarUrl(id) : undefined;
+});
+const avatarAlt = computed(() => user.value?.username ?? user.value?.display_name ?? "");
+
 const closeSidebar = () => {
   open.value = false;
 };
@@ -60,7 +66,11 @@ const userItems = computed<DropdownMenuItem[][]>(() => [
   [
     {
       label: user.value?.username ?? user.value?.display_name ?? "",
-      avatar: { icon: "i-lucide-user" },
+      avatar: {
+        src: avatarUrl.value,
+        alt: avatarAlt.value,
+        icon: avatarUrl.value ? undefined : "i-lucide-user",
+      },
       type: "label",
     },
     {
@@ -125,7 +135,12 @@ const userItems = computed<DropdownMenuItem[][]>(() => [
             :class="collapsed ? 'justify-center' : 'justify-start'"
             :block="!collapsed"
           >
-            <UAvatar :icon="collapsed ? 'i-lucide-user' : undefined" size="2xs" />
+            <UAvatar
+              :src="avatarUrl"
+              :alt="avatarAlt"
+              :icon="avatarUrl ? undefined : 'i-lucide-user'"
+              size="2xs"
+            />
             <span v-if="!collapsed" class="truncate">
               {{ user.username ?? user.display_name }}
             </span>

--- a/app/pages/settings/account.vue
+++ b/app/pages/settings/account.vue
@@ -49,8 +49,13 @@ async function onSubmit(event: FormSubmitEvent<ChangePasswordValues>) {
 
     <UPageCard v-if="user" variant="subtle">
       <div class="flex flex-col gap-3">
-        <div class="flex max-sm:flex-col justify-between items-start gap-2">
-          <span class="text-muted">{{ $t("auth.account.username") }}</span>
+        <div class="flex items-center gap-3">
+          <UAvatar
+            :src="user.user_id ? userAvatarUrl(user.user_id) : undefined"
+            :alt="user.username ?? user.display_name"
+            :icon="user.user_id ? undefined : 'i-lucide-user'"
+            size="lg"
+          />
           <span class="font-medium">{{ user.username ?? user.display_name }}</span>
         </div>
         <USeparator />

--- a/app/pages/settings/users.vue
+++ b/app/pages/settings/users.vue
@@ -66,9 +66,12 @@ async function onDelete(target: User) {
       <div class="flex flex-col gap-2">
         <UPageCard v-for="u in data" :key="u.id" variant="subtle">
           <div class="flex sm:items-center justify-between gap-3">
-            <div class="flex flex-col">
-              <span class="font-medium">{{ u.username }}</span>
-              <span class="text-muted text-xs">{{ u.id }}</span>
+            <div class="flex items-center gap-3 min-w-0">
+              <UAvatar :src="userAvatarUrl(u.id)" :alt="u.username" size="sm" />
+              <div class="flex flex-col min-w-0">
+                <span class="font-medium truncate">{{ u.username }}</span>
+                <span class="text-muted text-xs">{{ u.id }}</span>
+              </div>
             </div>
             <div class="flex items-center gap-3">
               <UBadge

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -60,7 +60,6 @@
     "account": {
       "title": "Konto",
       "description": "Deine Kontodetails und dein Passwort.",
-      "username": "Benutzername",
       "role": "Rolle"
     },
     "users": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -60,7 +60,6 @@
     "account": {
       "title": "Account",
       "description": "Your account details and password.",
-      "username": "Username",
       "role": "Role"
     },
     "users": {

--- a/modules/aperture/module.ts
+++ b/modules/aperture/module.ts
@@ -12,6 +12,7 @@ export default defineNuxtModule({
       { name: "apertureApi", from: resolve("./runtime/client") },
       { name: "ApiError", from: resolve("./runtime/client") },
       { name: "setUnauthorizedHandler", from: resolve("./runtime/client") },
+      { name: "userAvatarUrl", from: resolve("./runtime/client") },
     ]);
     addImportsDir(resolve("./runtime/composables"));
     addPlugin(resolve("./runtime/plugins/auth.client.ts"));

--- a/modules/aperture/runtime/client.ts
+++ b/modules/aperture/runtime/client.ts
@@ -189,3 +189,7 @@ export const apertureApi = {
     unwrapVoid(await client.DELETE("/api/v1/api-keys/{id}", { params: { path: { id } } }));
   },
 };
+
+export function userAvatarUrl(userId: string): string {
+  return `/api/v1/users/${userId}/avatar`;
+}


### PR DESCRIPTION
Renders constellation avatars in the sidebar, users list, and account
page, with an initials fallback for API-key sessions. Stacked on #242
for the aperture API spec (CurrentActorResponse rename + avatar
endpoint).