### PR TITLE
feat: aperture client for tasks, schedules, and artifacts

### DIFF
--- a/modules/aperture/module.ts
+++ b/modules/aperture/module.ts
@@ -13,6 +13,7 @@ export default defineNuxtModule({
       { name: "ApiError", from: resolve("./runtime/client") },
       { name: "setUnauthorizedHandler", from: resolve("./runtime/client") },
       { name: "userAvatarUrl", from: resolve("./runtime/client") },
+      { name: "artifactBlobUrl", from: resolve("./runtime/client") },
     ]);
     addImportsDir(resolve("./runtime/composables"));
     addPlugin(resolve("./runtime/plugins/auth.client.ts"));

--- a/modules/aperture/runtime/client.ts
+++ b/modules/aperture/runtime/client.ts
@@ -2,18 +2,28 @@ import createClient from "openapi-fetch";
 import type { paths } from "./generated";
 import type {
   ApiKeyPage,
+  ArtifactSummary,
+  ArtifactSummaryPage,
+  ArtifactVersion,
+  ArtifactVersionPage,
   BootPage,
   BootResponse,
   ChangePasswordBody,
   CreateApiKeyBody,
+  CreateTaskBody,
+  CreateTaskScheduleBody,
   CreatedApiKey,
   CreateUserBody,
   CurrentActor,
   ListApiKeysParams,
+  ListArtifactVersionsParams,
+  ListArtifactsParams,
   ListLogBootsParams,
   ListLogSpansParams,
   ListLogTargetsParams,
   ListLogsParams,
+  ListTaskSchedulesParams,
+  ListTasksParams,
   ListUsersParams,
   LoginBody,
   LoginResponse,
@@ -22,13 +32,23 @@ import type {
   LogSpan,
   LogSpanDetail,
   LogSpanPage,
+  RawArtifactSummary,
+  RawArtifactVersion,
   RawBootResponse,
   RawLogEvent,
   RawLogSpan,
   RawLogSpanDetail,
+  RawTask,
+  RawTaskSchedule,
   SetupBody,
   SetupStatus,
   StringPage,
+  Task,
+  TaskDefinition,
+  TaskPage,
+  TaskSchedule,
+  TaskSchedulePage,
+  UpdateTaskScheduleBody,
   User,
   UserPage,
   VersionResponse,
@@ -120,6 +140,39 @@ function toBootResponse(b: RawBootResponse): BootResponse {
   };
 }
 
+function toTask(t: RawTask): Task {
+  const { created_at, started_at, finished_at, ...rest } = t;
+  return {
+    ...rest,
+    created_at: Temporal.Instant.from(created_at),
+    started_at: started_at ? Temporal.Instant.from(started_at) : null,
+    finished_at: finished_at ? Temporal.Instant.from(finished_at) : null,
+  };
+}
+
+function toTaskSchedule(s: RawTaskSchedule): TaskSchedule {
+  const { created_at, next_run_at, last_run_at, ...rest } = s;
+  return {
+    ...rest,
+    created_at: Temporal.Instant.from(created_at),
+    next_run_at: Temporal.Instant.from(next_run_at),
+    last_run_at: last_run_at ? Temporal.Instant.from(last_run_at) : null,
+  };
+}
+
+function toArtifactSummary(a: RawArtifactSummary): ArtifactSummary {
+  return { ...a, downloaded_at: Temporal.Instant.from(a.downloaded_at) };
+}
+
+function toArtifactVersion(v: RawArtifactVersion): ArtifactVersion {
+  const { downloaded_at, verified_at, ...rest } = v;
+  return {
+    ...rest,
+    downloaded_at: Temporal.Instant.from(downloaded_at),
+    verified_at: verified_at ? Temporal.Instant.from(verified_at) : null,
+  };
+}
+
 export const apertureApi = {
   getVersion: async (): Promise<VersionResponse> => unwrap(await client.GET("/api/v1/version")),
 
@@ -184,8 +237,102 @@ export const apertureApi = {
   deleteApiKey: async (id: string): Promise<void> => {
     unwrapVoid(await client.DELETE("/api/v1/api-keys/{id}", { params: { path: { id } } }));
   },
+
+  listTasks: async (params?: ListTasksParams): Promise<TaskPage> => {
+    const data = unwrap(await client.GET("/api/v1/tasks", { params: { query: params } }));
+    return { ...data, items: data.items.map(toTask) };
+  },
+
+  getTask: async (id: string): Promise<Task> =>
+    toTask(unwrap(await client.GET("/api/v1/tasks/{id}", { params: { path: { id } } }))),
+
+  createTask: async (body: CreateTaskBody): Promise<Task> =>
+    toTask(unwrap(await client.POST("/api/v1/tasks", { body }))),
+
+  cancelTask: async (id: string): Promise<void> => {
+    unwrapVoid(await client.POST("/api/v1/tasks/{id}/cancel", { params: { path: { id } } }));
+  },
+
+  listTaskDefinitions: async (): Promise<TaskDefinition[]> =>
+    unwrap(await client.GET("/api/v1/task-definitions")),
+
+  listTaskSchedules: async (params?: ListTaskSchedulesParams): Promise<TaskSchedulePage> => {
+    const data = unwrap(await client.GET("/api/v1/task-schedules", { params: { query: params } }));
+    return { ...data, items: data.items.map(toTaskSchedule) };
+  },
+
+  getTaskSchedule: async (id: string): Promise<TaskSchedule> =>
+    toTaskSchedule(
+      unwrap(await client.GET("/api/v1/task-schedules/{id}", { params: { path: { id } } })),
+    ),
+
+  createTaskSchedule: async (body: CreateTaskScheduleBody): Promise<TaskSchedule> =>
+    toTaskSchedule(unwrap(await client.POST("/api/v1/task-schedules", { body }))),
+
+  updateTaskSchedule: async (id: string, body: UpdateTaskScheduleBody): Promise<TaskSchedule> =>
+    toTaskSchedule(
+      unwrap(await client.PATCH("/api/v1/task-schedules/{id}", { params: { path: { id } }, body })),
+    ),
+
+  deleteTaskSchedule: async (id: string): Promise<void> => {
+    unwrapVoid(await client.DELETE("/api/v1/task-schedules/{id}", { params: { path: { id } } }));
+  },
+
+  listArtifacts: async (params?: ListArtifactsParams): Promise<ArtifactSummaryPage> => {
+    const data = unwrap(await client.GET("/api/v1/artifacts", { params: { query: params } }));
+    return { ...data, items: data.items.map(toArtifactSummary) };
+  },
+
+  getArtifact: async (key: string): Promise<ArtifactSummary> =>
+    toArtifactSummary(
+      unwrap(await client.GET("/api/v1/artifacts/{key}", { params: { path: { key } } })),
+    ),
+
+  uploadArtifact: async (key: string, body: Blob): Promise<ArtifactVersion> =>
+    toArtifactVersion(
+      unwrap(
+        await client.PUT("/api/v1/artifacts/{key}", {
+          params: { path: { key } },
+          body: body as unknown as BodyInit,
+          headers: { "Content-Type": "application/octet-stream" },
+        }),
+      ),
+    ),
+
+  listArtifactVersions: async (
+    key: string,
+    params?: ListArtifactVersionsParams,
+  ): Promise<ArtifactVersionPage> => {
+    const data = unwrap(
+      await client.GET("/api/v1/artifacts/{key}/versions", {
+        params: { path: { key }, query: params },
+      }),
+    );
+    return { ...data, items: data.items.map(toArtifactVersion) };
+  },
+
+  getArtifactVersion: async (key: string, digest: string): Promise<ArtifactVersion> =>
+    toArtifactVersion(
+      unwrap(
+        await client.GET("/api/v1/artifacts/{key}/versions/{digest}", {
+          params: { path: { key, digest } },
+        }),
+      ),
+    ),
+
+  deleteArtifactVersion: async (key: string, digest: string): Promise<void> => {
+    unwrapVoid(
+      await client.DELETE("/api/v1/artifacts/{key}/versions/{digest}", {
+        params: { path: { key, digest } },
+      }),
+    );
+  },
 };
 
 export function userAvatarUrl(userId: string): string {
   return `/api/v1/users/${userId}/avatar`;
+}
+
+export function artifactBlobUrl(key: string, digest: string): string {
+  return `/api/v1/artifacts/${encodeURIComponent(key)}/versions/${encodeURIComponent(digest)}/blob`;
 }

--- a/modules/aperture/runtime/types.ts
+++ b/modules/aperture/runtime/types.ts
@@ -39,6 +39,10 @@ export type BootPage = Page<BootResponse>;
 export type UserPage = Page<User>;
 export type ApiKeyPage = Page<ApiKey>;
 export type StringPage = Page<string>;
+export type TaskPage = Page<Task>;
+export type TaskSchedulePage = Page<TaskSchedule>;
+export type ArtifactSummaryPage = Page<ArtifactSummary>;
+export type ArtifactVersionPage = Page<ArtifactVersion>;
 
 export type ListLogsParams = NonNullable<operations["listLogs"]["parameters"]["query"]>;
 export type ListLogSpansParams = NonNullable<operations["listSpans"]["parameters"]["query"]>;
@@ -46,6 +50,14 @@ export type ListLogTargetsParams = NonNullable<operations["listLogTargets"]["par
 export type ListLogBootsParams = NonNullable<operations["listLogBoots"]["parameters"]["query"]>;
 export type ListUsersParams = NonNullable<operations["listUsers"]["parameters"]["query"]>;
 export type ListApiKeysParams = NonNullable<operations["listApiKeys"]["parameters"]["query"]>;
+export type ListTasksParams = NonNullable<operations["listTasks"]["parameters"]["query"]>;
+export type ListTaskSchedulesParams = NonNullable<
+  operations["listTaskSchedules"]["parameters"]["query"]
+>;
+export type ListArtifactsParams = NonNullable<operations["listArtifacts"]["parameters"]["query"]>;
+export type ListArtifactVersionsParams = NonNullable<
+  operations["listArtifactVersions"]["parameters"]["query"]
+>;
 
 export type Role = Schemas["Role"];
 export type CurrentActor = Schemas["CurrentActorResponse"];
@@ -55,8 +67,42 @@ export type User = Schemas["UserResponse"];
 export type ApiKey = Schemas["ApiKeyResponse"];
 export type CreatedApiKey = Schemas["CreateApiKeyResponse"];
 
+export type TaskStatus = Schemas["TaskStatusResponse"];
+export type TaskStatusParam = Schemas["TaskStatusParam"];
+export type TaskProgress = Schemas["ProgressResponse"];
+export type TaskProgressMessage = Schemas["ProgressMessageResponse"];
+export type TaskDefinition = Schemas["TaskDefinitionResponse"];
+
+export type RawTask = Schemas["TaskResponse"];
+export type Task = Omit<RawTask, "created_at" | "started_at" | "finished_at"> & {
+  created_at: Temporal.Instant;
+  started_at: Temporal.Instant | null;
+  finished_at: Temporal.Instant | null;
+};
+
+export type RawTaskSchedule = Schemas["TaskScheduleResponse"];
+export type TaskSchedule = Omit<RawTaskSchedule, "created_at" | "next_run_at" | "last_run_at"> & {
+  created_at: Temporal.Instant;
+  next_run_at: Temporal.Instant;
+  last_run_at: Temporal.Instant | null;
+};
+
+export type RawArtifactSummary = Schemas["ArtifactSummaryResponse"];
+export type ArtifactSummary = Omit<RawArtifactSummary, "downloaded_at"> & {
+  downloaded_at: Temporal.Instant;
+};
+
+export type RawArtifactVersion = Schemas["ArtifactVersionResponse"];
+export type ArtifactVersion = Omit<RawArtifactVersion, "downloaded_at" | "verified_at"> & {
+  downloaded_at: Temporal.Instant;
+  verified_at: Temporal.Instant | null;
+};
+
 export type LoginBody = Schemas["LoginRequest"];
 export type SetupBody = Schemas["SetupRequest"];
 export type ChangePasswordBody = Schemas["ChangePasswordRequest"];
 export type CreateUserBody = Schemas["CreateUserRequest"];
 export type CreateApiKeyBody = Schemas["CreateApiKeyRequest"];
+export type CreateTaskBody = Schemas["CreateTaskInput"];
+export type CreateTaskScheduleBody = Schemas["CreateTaskScheduleRequest"];
+export type UpdateTaskScheduleBody = Schemas["UpdateTaskScheduleRequest"];


### PR DESCRIPTION
Typed client layer for the operations endpoints: tasks (list, get,
create, cancel), task definitions, task schedules CRUD, and artifacts
(list, versions, upload, evict, blob URL helper). Date fields are
converted to Temporal.Instant.