### PR TITLE
feat: operations section with tasks list

### DIFF
--- a/app/composables/useTasksFilters.ts
+++ b/app/composables/useTasksFilters.ts
@@ -1,7 +1,10 @@
 import * as z from "zod/v4/mini";
-import type { ListTasksParams } from "~~/modules/aperture/runtime/types";
+import type { ListTasksParams, TaskStatusParam } from "~~/modules/aperture/runtime/types";
 import { queryOptionalString, useRouteQueryState } from "~/composables/useRouteQueryState";
 
+// openapi-typescript emits types only, so there is no runtime array to import
+// from the generated code. `satisfies` pins the values to the TaskStatusParam
+// union and the assertion below fails if the spec grows a new status.
 export const TASK_STATUS_FILTERS = [
   "active",
   "finished",
@@ -10,16 +13,18 @@ export const TASK_STATUS_FILTERS = [
   "succeeded",
   "failed",
   "cancelled",
-  "interrupted",
-] as const;
+] as const satisfies readonly TaskStatusParam[];
 
-export type TaskStatusFilter = (typeof TASK_STATUS_FILTERS)[number];
+type AssertNever<T extends never> = T;
+export type TaskStatusFiltersComplete = AssertNever<
+  Exclude<TaskStatusParam, (typeof TASK_STATUS_FILTERS)[number]>
+>;
 
-export function isTaskStatusFilter(value: string): value is TaskStatusFilter {
+export function isTaskStatusFilter(value: string): value is TaskStatusParam {
   return (TASK_STATUS_FILTERS as readonly string[]).includes(value);
 }
 
-const queryStatusFilter = z.codec(z.array(z.string()), z.custom<TaskStatusFilter | undefined>(), {
+const queryStatusFilter = z.codec(z.array(z.string()), z.custom<TaskStatusParam | undefined>(), {
   decode: (arr) => {
     const v = arr[0];
     return v !== undefined && isTaskStatusFilter(v) ? v : undefined;

--- a/app/composables/useTasksFilters.ts
+++ b/app/composables/useTasksFilters.ts
@@ -1,11 +1,9 @@
 import * as z from "zod/v4/mini";
 import type { ListTasksParams, TaskStatusParam } from "~~/modules/aperture/runtime/types";
 import { queryOptionalString, useRouteQueryState } from "~/composables/useRouteQueryState";
+import { assertUnionCoverage } from "~/utils/union";
 
-// openapi-typescript emits types only, so there is no runtime array to import
-// from the generated code. `satisfies` pins the values to the TaskStatusParam
-// union and the assertion below fails if the spec grows a new status.
-export const TASK_STATUS_FILTERS = [
+export const TASK_STATUS_FILTERS = assertUnionCoverage<TaskStatusParam>()([
   "active",
   "finished",
   "pending",
@@ -13,12 +11,8 @@ export const TASK_STATUS_FILTERS = [
   "succeeded",
   "failed",
   "cancelled",
-] as const satisfies readonly TaskStatusParam[];
-
-type AssertNever<T extends never> = T;
-export type TaskStatusFiltersComplete = AssertNever<
-  Exclude<TaskStatusParam, (typeof TASK_STATUS_FILTERS)[number]>
->;
+  "interrupted",
+] as const);
 
 export function isTaskStatusFilter(value: string): value is TaskStatusParam {
   return (TASK_STATUS_FILTERS as readonly string[]).includes(value);

--- a/app/composables/useTasksFilters.ts
+++ b/app/composables/useTasksFilters.ts
@@ -1,0 +1,63 @@
+import * as z from "zod/v4/mini";
+import type { ListTasksParams } from "~~/modules/aperture/runtime/types";
+import { queryOptionalString, useRouteQueryState } from "~/composables/useRouteQueryState";
+
+export const TASK_STATUS_FILTERS = [
+  "active",
+  "finished",
+  "pending",
+  "running",
+  "succeeded",
+  "failed",
+  "cancelled",
+  "interrupted",
+] as const;
+
+export type TaskStatusFilter = (typeof TASK_STATUS_FILTERS)[number];
+
+export function isTaskStatusFilter(value: string): value is TaskStatusFilter {
+  return (TASK_STATUS_FILTERS as readonly string[]).includes(value);
+}
+
+const queryStatusFilter = z.codec(z.array(z.string()), z.custom<TaskStatusFilter | undefined>(), {
+  decode: (arr) => {
+    const v = arr[0];
+    return v !== undefined && isTaskStatusFilter(v) ? v : undefined;
+  },
+  encode: (v) => (v ? [v] : []),
+});
+
+const queryRootDefaultTrue = z.codec(z.array(z.string()), z.boolean(), {
+  decode: (arr) => (arr[0] === undefined ? true : arr[0] === "1"),
+  encode: (v) => (v ? ["1"] : ["0"]),
+});
+
+export const tasksSchema = z.object({
+  status: queryStatusFilter,
+  kind: queryOptionalString(),
+  root: queryRootDefaultTrue,
+});
+
+export type TasksFilters = z.infer<typeof tasksSchema>;
+
+export const tasksQueryKeys: Partial<Record<keyof TasksFilters, string>> = {
+  status: "status",
+  kind: "kind",
+  root: "root",
+};
+
+export function defaultTasksFilters(): TasksFilters {
+  return { status: undefined, kind: undefined, root: true };
+}
+
+export function useTasksFilters(): TasksFilters {
+  return useRouteQueryState(tasksSchema, { keys: tasksQueryKeys });
+}
+
+export function tasksParamsFromFilters(filters: TasksFilters): ListTasksParams {
+  const p: ListTasksParams = {};
+  if (filters.status) p.status = filters.status;
+  if (filters.kind) p.kind = filters.kind;
+  p.root = filters.root;
+  return p;
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -32,6 +32,32 @@ const links = computed(() => [
   ],
   [
     {
+      label: t("operations.title"),
+      icon: "i-lucide-list-checks",
+      to: localePath("/operations/tasks"),
+      onSelect: closeSidebar,
+      children: [
+        {
+          label: t("operations.tasks.title"),
+          icon: "i-lucide-list-checks",
+          to: localePath("/operations/tasks"),
+          onSelect: closeSidebar,
+        },
+        {
+          label: t("operations.schedules.title"),
+          icon: "i-lucide-calendar-clock",
+          to: localePath("/operations/schedules"),
+          onSelect: closeSidebar,
+        },
+        {
+          label: t("operations.artifacts.title"),
+          icon: "i-lucide-package",
+          to: localePath("/operations/artifacts"),
+          onSelect: closeSidebar,
+        },
+      ],
+    },
+    {
       label: t("developer.title"),
       icon: "i-lucide-terminal-square",
       to: localePath("/developer"),

--- a/app/pages/operations/artifacts.vue
+++ b/app/pages/operations/artifacts.vue
@@ -1,0 +1,5 @@
+<template>
+  <AppPage :title="$t('operations.artifacts.title')">
+    <div class="p-6 text-muted">{{ $t("common.notImplemented") }}</div>
+  </AppPage>
+</template>

--- a/app/pages/operations/schedules.vue
+++ b/app/pages/operations/schedules.vue
@@ -1,0 +1,5 @@
+<template>
+  <AppPage :title="$t('operations.schedules.title')">
+    <div class="p-6 text-muted">{{ $t("common.notImplemented") }}</div>
+  </AppPage>
+</template>

--- a/app/pages/operations/tasks.vue
+++ b/app/pages/operations/tasks.vue
@@ -1,0 +1,225 @@
+<script setup lang="ts">
+import type { SelectMenuItem } from "@nuxt/ui";
+import { useIntervalFn } from "@vueuse/core";
+import type {
+  ListTasksParams,
+  Task,
+  TaskDefinition,
+  TaskStatus,
+} from "~~/modules/aperture/runtime/types";
+import {
+  TASK_STATUS_FILTERS,
+  tasksParamsFromFilters,
+  useTasksFilters,
+} from "~/composables/useTasksFilters";
+
+const { t, te } = useI18n();
+const fmt = useFormatter();
+
+const filters = useTasksFilters();
+
+const { data: definitions } = useAsyncData<TaskDefinition[]>(
+  "task-definitions",
+  () => apertureApi.listTaskDefinitions(),
+  { server: false },
+);
+
+const params = computed(() => tasksParamsFromFilters(filters));
+
+const {
+  items: tasks,
+  pending,
+  error,
+  hasNext,
+  hasPrev,
+  loadNext,
+  loadPrev,
+  reload,
+} = useCursorPager<Task, ListTasksParams>(
+  (query) => apertureApi.listTasks(query),
+  () => params.value,
+);
+
+const STATUS_COLORS: Record<TaskStatus, "neutral" | "primary" | "success" | "error" | "warning"> = {
+  pending: "neutral",
+  running: "primary",
+  succeeded: "success",
+  failed: "error",
+  cancelled: "warning",
+  interrupted: "warning",
+};
+
+const statusItems = computed<SelectMenuItem[]>(() => [
+  { label: t("operations.tasks.filters.statusAll"), value: undefined },
+  ...TASK_STATUS_FILTERS.map((s) => ({
+    label: t(`operations.tasks.status.${s}`),
+    value: s,
+  })),
+]);
+
+const kindItems = computed<SelectMenuItem[]>(() => [
+  { label: t("operations.tasks.filters.kindAll"), value: undefined },
+  ...(definitions.value ?? []).map((d) => ({ label: d.kind, value: d.kind })),
+]);
+
+function formatTimestamp(ts: Temporal.Instant): string {
+  return fmt.date(ts, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatDuration(task: Task): string {
+  if (!task.started_at) return t("operations.tasks.notStarted");
+  if (!task.finished_at) return t("operations.tasks.status.running");
+  return fmt.duration(task.finished_at.since(task.started_at), { fractionDigits: 1 });
+}
+
+function progressPercent(task: Task): number | null {
+  const p = task.progress;
+  if (!p?.total || p.done == null || p.total <= 0) return null;
+  return Math.min(100, Math.round((p.done / p.total) * 100));
+}
+
+function progressMessage(task: Task): string | null {
+  const msg = task.progress?.message;
+  if (!msg) return null;
+  return te(msg.key) ? t(msg.key, msg.args) : msg.key;
+}
+
+const hasActiveTasks = computed(() =>
+  tasks.value.some((task) => task.status === "pending" || task.status === "running"),
+);
+
+const { pause, resume } = useIntervalFn(() => void reload(), 3000);
+
+watch(hasActiveTasks, (active) => (active ? resume() : pause()), { immediate: true });
+
+onUnmounted(pause);
+</script>
+
+<template>
+  <AppPage :title="$t('operations.tasks.title')">
+    <template #toolbar>
+      <div class="flex flex-wrap items-center gap-2 px-4 py-2 border-b border-default">
+        <USelectMenu
+          v-model="filters.status"
+          :items="statusItems"
+          value-attribute="value"
+          size="sm"
+          class="w-44"
+        />
+
+        <USelectMenu
+          v-model="filters.kind"
+          :items="kindItems"
+          value-attribute="value"
+          size="sm"
+          class="w-44"
+        />
+
+        <UCheckbox
+          :model-value="filters.root"
+          :label="$t('operations.tasks.filters.rootOnly')"
+          size="sm"
+          @update:model-value="(v) => (filters.root = v === true)"
+        />
+
+        <UButton
+          variant="ghost"
+          color="neutral"
+          icon="i-lucide-refresh-cw"
+          size="sm"
+          :label="$t('operations.tasks.refresh')"
+          :loading="pending && tasks.length === 0"
+          class="ms-auto"
+          @click="reload()"
+        />
+      </div>
+    </template>
+
+    <div class="p-4">
+      <DataState
+        :pending="pending && tasks.length === 0"
+        :error="error ? String(error) : null"
+        :empty="tasks.length === 0"
+        :empty-text="$t('operations.tasks.empty')"
+        :error-text="$t('operations.tasks.error')"
+        :retry-text="$t('common.retry')"
+        @retry="reload()"
+      >
+        <div class="flex flex-col gap-2">
+          <UPageCard v-for="task in tasks" :key="task.id" variant="subtle">
+            <div class="flex flex-col gap-2">
+              <div class="flex flex-wrap sm:items-center justify-between gap-3">
+                <div class="flex items-center gap-3 min-w-0">
+                  <UBadge
+                    :label="$t(`operations.tasks.status.${task.status}`)"
+                    :color="STATUS_COLORS[task.status]"
+                    variant="subtle"
+                  />
+                  <span class="font-mono text-sm truncate">{{ task.kind }}</span>
+                  <span class="text-muted text-xs font-mono hidden md:inline">{{ task.id }}</span>
+                </div>
+                <div class="flex items-center gap-3 text-xs text-muted">
+                  <span>{{ formatTimestamp(task.created_at) }}</span>
+                  <span class="tabular-nums">{{ formatDuration(task) }}</span>
+                </div>
+              </div>
+
+              <div v-if="task.status === 'running'" class="flex items-center gap-3">
+                <UProgress
+                  v-if="progressPercent(task) !== null"
+                  :model-value="progressPercent(task)!"
+                  size="sm"
+                  class="flex-1"
+                />
+                <span v-else class="flex items-center gap-2 text-xs text-muted">
+                  <LoadingSpinner class="size-3.5" />
+                  {{ progressMessage(task) ?? $t("operations.tasks.status.running") }}
+                </span>
+                <span
+                  v-if="progressPercent(task) !== null"
+                  class="text-xs text-muted tabular-nums w-10 text-end"
+                >
+                  {{ progressPercent(task) }}%
+                </span>
+              </div>
+
+              <p
+                v-if="task.error"
+                class="text-xs text-error font-mono break-all whitespace-pre-wrap"
+              >
+                {{ task.error }}
+              </p>
+
+              <p
+                v-else-if="
+                  task.status === 'running' &&
+                  progressPercent(task) !== null &&
+                  progressMessage(task)
+                "
+                class="text-xs text-muted truncate"
+              >
+                {{ progressMessage(task) }}
+              </p>
+            </div>
+          </UPageCard>
+        </div>
+
+        <PagerBar
+          :has-prev="hasPrev"
+          :has-next="hasNext"
+          :pending="pending && tasks.length === 0"
+          :prev-text="$t('common.prev')"
+          :next-text="$t('common.next')"
+          @prev="loadPrev()"
+          @next="loadNext()"
+        />
+      </DataState>
+    </div>
+  </AppPage>
+</template>

--- a/app/pages/settings/api-keys.vue
+++ b/app/pages/settings/api-keys.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { FormSubmitEvent, SelectMenuItem } from "@nuxt/ui";
 import type { ApiKey, CreatedApiKey } from "~~/modules/aperture/runtime/types";
-import { createApiKeySchema, type CreateApiKeyValues } from "~/utils/auth";
+import { createApiKeySchema, type CreateApiKeyValues, ROLES } from "~/utils/auth";
 
 const { t } = useI18n();
 const toast = useToast();
@@ -28,7 +28,7 @@ const copied = ref(false);
 
 const roleItems = computed<SelectMenuItem[]>(() => [
   { label: t("auth.apiKeys.noRole"), value: undefined },
-  ...(["admin", "operator", "viewer"] as const).map((r) => ({
+  ...ROLES.map((r) => ({
     label: t(`auth.roles.${r}`),
     value: r,
   })),

--- a/app/pages/settings/users.vue
+++ b/app/pages/settings/users.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { FormSubmitEvent, SelectMenuItem } from "@nuxt/ui";
 import type { User } from "~~/modules/aperture/runtime/types";
-import { createUserSchema, type CreateUserValues } from "~/utils/auth";
+import { createUserSchema, type CreateUserValues, ROLES } from "~/utils/auth";
 
 const { t } = useI18n();
 const toast = useToast();
@@ -27,7 +27,7 @@ const createState = reactive({
 const creating = ref(false);
 
 const roleItems = computed<SelectMenuItem[]>(() =>
-  (["admin", "operator", "viewer"] as const).map((r) => ({
+  ROLES.map((r) => ({
     label: t(`auth.roles.${r}`),
     value: r,
   })),

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -1,9 +1,12 @@
 import * as z from "zod/v4/mini";
 import type { Role } from "~~/modules/aperture/runtime/types";
+import { assertUnionCoverage } from "~/utils/union";
 
 export const USERNAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 export const PASSWORD_MIN = 12;
 export const PASSWORD_MAX = 1024;
+
+export const ROLES = assertUnionCoverage<Role>()(["admin", "operator", "viewer"] as const);
 
 export interface PasswordRequirement {
   key: string;
@@ -21,7 +24,7 @@ export function passwordRequirements(value: string): PasswordRequirement[] {
 const requiredString = z.string().check(z.minLength(1));
 const usernameField = z.string().check(z.minLength(1), z.maxLength(64), z.regex(USERNAME_PATTERN));
 const newPasswordField = z.string().check(z.minLength(PASSWORD_MIN), z.maxLength(PASSWORD_MAX));
-const roleField = z.optional(z.enum(["admin", "operator", "viewer"]));
+const roleField = z.optional(z.enum(ROLES));
 
 export type LoginValues = z.infer<typeof loginSchema>;
 export const loginSchema = z.object({
@@ -57,5 +60,5 @@ export const createApiKeySchema = z.object({
 });
 
 export function isRole(value: string): value is Role {
-  return value === "admin" || value === "operator" || value === "viewer";
+  return (ROLES as readonly string[]).includes(value);
 }

--- a/app/utils/logLevels.ts
+++ b/app/utils/logLevels.ts
@@ -1,8 +1,17 @@
+import type { LevelResponse } from "~~/modules/aperture/runtime/types";
+import { assertUnionCoverage } from "~/utils/union";
+
 export type BadgeColor =
   "error" | "primary" | "secondary" | "success" | "info" | "warning" | "neutral";
 
-export const LOG_LEVELS = ["trace", "debug", "info", "warn", "error"] as const;
-export type LogLevel = (typeof LOG_LEVELS)[number];
+export const LOG_LEVELS = assertUnionCoverage<LevelResponse>()([
+  "trace",
+  "debug",
+  "info",
+  "warn",
+  "error",
+] as const);
+export type LogLevel = LevelResponse;
 
 export function isLogLevel(value: string): value is LogLevel {
   return (LOG_LEVELS as readonly string[]).includes(value);

--- a/app/utils/union.ts
+++ b/app/utils/union.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns `values` unchanged and fails to compile unless the array covers
+ * every member of `union`.
+ *
+ *     const LEVELS = assertUnionCoverage<Level>()(["low", "high"] as const);
+ */
+export function assertUnionCoverage<Union extends string>() {
+  return <Values extends readonly Union[]>(
+    values: Values & ([Exclude<Union, Values[number]>] extends [never] ? unknown : never),
+  ): Values => values;
+}

--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -1,0 +1,100 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { expect, test } from "@playwright/test";
+
+const TASKS_PATH = "/api/v1/tasks";
+
+function iso(msAgo: number): string {
+  return new Temporal.Instant(
+    BigInt(Temporal.Now.instant().epochMilliseconds - msAgo) * 1_000_000n,
+  ).toString();
+}
+
+const stubTasks = [
+  {
+    id: "task-1",
+    kind: "download",
+    status: "succeeded",
+    input: {},
+    created_at: iso(60_000),
+    started_at: iso(59_000),
+    finished_at: iso(30_000),
+  },
+  {
+    id: "task-2",
+    kind: "rotate-certificate",
+    status: "running",
+    input: {},
+    created_at: iso(10_000),
+    started_at: iso(9_000),
+    progress: { done: 4, total: 10, message: null },
+  },
+];
+
+test("tasks list renders statuses and progress", async ({ page }) => {
+  const taskRequests: string[] = [];
+
+  await page.route("**/api/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === TASKS_PATH) {
+      taskRequests.push(url.search);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: stubTasks, next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/task-definitions") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.goto("/en/operations/tasks", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByText("download", { exact: true })).toBeVisible();
+  await expect(page.getByText("rotate-certificate", { exact: true })).toBeVisible();
+  await expect(page.getByText("Succeeded")).toBeVisible();
+  await expect(page.getByText("40%")).toBeVisible();
+
+  // The list asks for top-level tasks only by default.
+  expect(taskRequests[0]).toContain("root=true");
+});

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -12,7 +12,9 @@
     "create": "Erstellen",
     "done": "Fertig",
     "next": "Weiter",
-    "prev": "Zurück"
+    "notImplemented": "Noch nicht implementiert.",
+    "prev": "Zurück",
+    "retry": "Erneut versuchen"
   },
   "auth": {
     "roles": {
@@ -213,6 +215,37 @@
       "spanId": "Span",
       "childSpans": "Untergeordnete Spans",
       "noChildSpans": "Keine untergeordneten Spans"
+    }
+  },
+  "operations": {
+    "title": "Betrieb",
+    "tasks": {
+      "title": "Aufgaben",
+      "empty": "Keine Aufgaben gefunden.",
+      "error": "Aufgaben konnten nicht geladen werden.",
+      "refresh": "Aktualisieren",
+      "notStarted": "Nicht gestartet",
+      "filters": {
+        "statusAll": "Alle Status",
+        "kindAll": "Alle Arten",
+        "rootOnly": "Nur oberste Ebene"
+      },
+      "status": {
+        "pending": "Ausstehend",
+        "running": "Läuft",
+        "succeeded": "Erfolgreich",
+        "failed": "Fehlgeschlagen",
+        "cancelled": "Abgebrochen",
+        "interrupted": "Unterbrochen",
+        "active": "Aktiv",
+        "finished": "Beendet"
+      }
+    },
+    "schedules": {
+      "title": "Zeitpläne"
+    },
+    "artifacts": {
+      "title": "Artefakte"
     }
   },
   "units": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -12,7 +12,9 @@
     "create": "Create",
     "done": "Done",
     "next": "Next",
-    "prev": "Previous"
+    "notImplemented": "Not implemented yet.",
+    "prev": "Previous",
+    "retry": "Retry"
   },
   "auth": {
     "roles": {
@@ -213,6 +215,37 @@
       "spanId": "Span",
       "childSpans": "Child spans",
       "noChildSpans": "No child spans"
+    }
+  },
+  "operations": {
+    "title": "Operations",
+    "tasks": {
+      "title": "Tasks",
+      "empty": "No tasks found.",
+      "error": "Failed to load tasks.",
+      "refresh": "Refresh",
+      "notStarted": "Not started",
+      "filters": {
+        "statusAll": "All statuses",
+        "kindAll": "All kinds",
+        "rootOnly": "Top-level only"
+      },
+      "status": {
+        "pending": "Pending",
+        "running": "Running",
+        "succeeded": "Succeeded",
+        "failed": "Failed",
+        "cancelled": "Cancelled",
+        "interrupted": "Interrupted",
+        "active": "Active",
+        "finished": "Finished"
+      }
+    },
+    "schedules": {
+      "title": "Schedules"
+    },
+    "artifacts": {
+      "title": "Artifacts"
     }
   },
   "units": {


### PR DESCRIPTION
Adds an Operations nav group (tasks, schedules, artifacts) and the
tasks list page. Filters for status, kind, and top-level-only are
synced to the URL, the list pages with prev/next, and running tasks
show progress with 3s polling while any task is active. Schedules and
artifacts link to placeholders until their pages land.