### PR TITLE
feat: task detail page

### DIFF
--- a/app/composables/useTaskDisplay.ts
+++ b/app/composables/useTaskDisplay.ts
@@ -1,0 +1,47 @@
+import type { Task, TaskStatus } from "~~/modules/aperture/runtime/types";
+
+export type TaskStatusColor = "neutral" | "primary" | "success" | "error" | "warning";
+
+export const TASK_STATUS_COLORS: Record<TaskStatus, TaskStatusColor> = {
+  pending: "neutral",
+  running: "primary",
+  succeeded: "success",
+  failed: "error",
+  cancelled: "warning",
+  interrupted: "warning",
+};
+
+export function useTaskDisplay() {
+  const { t, te } = useI18n();
+  const fmt = useFormatter();
+
+  function formatTimestamp(ts: Temporal.Instant): string {
+    return fmt.date(ts, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  }
+
+  function formatDuration(task: Task): string {
+    if (!task.started_at) return t("operations.tasks.notStarted");
+    if (!task.finished_at) return t("operations.tasks.status.running");
+    return fmt.duration(task.finished_at.since(task.started_at), { fractionDigits: 1 });
+  }
+
+  function progressPercent(task: Task): number | null {
+    const p = task.progress;
+    if (!p?.total || p.done == null || p.total <= 0) return null;
+    return Math.min(100, Math.round((p.done / p.total) * 100));
+  }
+
+  function progressMessage(task: Task): string | null {
+    const msg = task.progress?.message;
+    if (!msg) return null;
+    return te(msg.key) ? t(msg.key, msg.args) : msg.key;
+  }
+
+  return { formatTimestamp, formatDuration, progressPercent, progressMessage };
+}

--- a/app/pages/operations/tasks/[id].vue
+++ b/app/pages/operations/tasks/[id].vue
@@ -1,0 +1,275 @@
+<script setup lang="ts">
+import { useIntervalFn } from "@vueuse/core";
+import type { ListTasksParams, Task, TaskDefinition } from "~~/modules/aperture/runtime/types";
+import { TASK_STATUS_COLORS, useTaskDisplay } from "~/composables/useTaskDisplay";
+
+const { t } = useI18n();
+const toast = useToast();
+const route = useRoute();
+const localePath = useLocalePath();
+const { formatTimestamp, formatDuration, progressPercent, progressMessage } = useTaskDisplay();
+
+const taskId = computed(() => String(route.params.id));
+
+const task = ref<Task | null>(null);
+const loadError = ref<unknown>(null);
+const loading = ref(false);
+
+const { data: definitionsData } = useAsyncData<TaskDefinition[]>(
+  "task-definitions",
+  () => apertureApi.listTaskDefinitions(),
+  { server: false },
+);
+
+const definition = computed<TaskDefinition | undefined>(() =>
+  (definitionsData.value ?? []).find((d) => d.kind === task.value?.kind),
+);
+
+async function load() {
+  loading.value = true;
+  loadError.value = null;
+  try {
+    task.value = await apertureApi.getTask(taskId.value);
+  } catch (err) {
+    loadError.value = err;
+  } finally {
+    loading.value = false;
+  }
+}
+
+const isActive = computed(
+  () => task.value?.status === "pending" || task.value?.status === "running",
+);
+
+const { pause, resume } = useIntervalFn(() => void load(), 3000);
+
+watch(isActive, (active) => (active ? resume() : pause()), { immediate: true });
+
+onUnmounted(pause);
+
+onMounted(() => void load());
+
+const canCancel = computed(() => {
+  if (!isActive.value) return false;
+  const def = definition.value;
+  return def ? def.cancellable : true;
+});
+
+const cancelling = ref(false);
+
+async function cancel() {
+  cancelling.value = true;
+  try {
+    await apertureApi.cancelTask(taskId.value);
+    toast.add({ title: t("operations.tasks.cancelRequested"), color: "success" });
+    await load();
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 409) {
+      toast.add({ title: t("operations.tasks.cancelNotCancellable"), color: "error" });
+    } else if (err instanceof ApiError && err.status === 410) {
+      toast.add({ title: t("operations.tasks.cancelAlreadyFinished"), color: "error" });
+    } else {
+      toast.add({ title: t("operations.tasks.cancelFailed"), color: "error" });
+    }
+  } finally {
+    cancelling.value = false;
+  }
+}
+
+function prettyJson(value: unknown): string {
+  return JSON.stringify(value ?? null, null, 2);
+}
+
+const {
+  items: children,
+  pending: childrenPending,
+  error: childrenError,
+  hasNext: childrenHasNext,
+  hasPrev: childrenHasPrev,
+  loadNext: childrenLoadNext,
+  loadPrev: childrenLoadPrev,
+  reload: childrenReload,
+} = useCursorPager<Task, ListTasksParams>(
+  (query) => apertureApi.listTasks(query),
+  () => ({ parent: taskId.value }),
+);
+</script>
+
+<template>
+  <AppPage :title="task?.kind ?? taskId" back-to="/operations/tasks">
+    <div class="p-4 flex flex-col gap-4">
+      <DataState
+        :pending="loading && !task"
+        :error="loadError ? String(loadError) : null"
+        :error-text="$t('operations.tasks.error')"
+        :retry-text="$t('common.retry')"
+        @retry="load()"
+      >
+        <div v-if="task" class="flex flex-col gap-4">
+          <UPageCard variant="subtle">
+            <div class="flex flex-col gap-3">
+              <div class="flex flex-wrap sm:items-center justify-between gap-3">
+                <div class="flex items-center gap-3 min-w-0">
+                  <UBadge
+                    :label="$t(`operations.tasks.status.${task.status}`)"
+                    :color="TASK_STATUS_COLORS[task.status]"
+                    variant="subtle"
+                  />
+                  <span class="font-mono text-sm truncate">{{ task.kind }}</span>
+                  <span class="text-muted text-xs font-mono">{{ task.id }}</span>
+                </div>
+                <div class="flex items-center gap-2">
+                  <UButton
+                    v-if="canCancel"
+                    icon="i-lucide-circle-stop"
+                    color="error"
+                    variant="soft"
+                    size="sm"
+                    :label="$t('operations.tasks.cancel')"
+                    :loading="cancelling"
+                    @click="cancel()"
+                  />
+                  <UButton
+                    icon="i-lucide-refresh-cw"
+                    color="neutral"
+                    variant="ghost"
+                    size="sm"
+                    :label="$t('operations.tasks.refresh')"
+                    :loading="loading"
+                    @click="load()"
+                  />
+                </div>
+              </div>
+
+              <div class="flex flex-wrap gap-x-8 gap-y-1 text-xs text-muted">
+                <span>
+                  {{ $t("operations.tasks.detail.createdAt") }}:
+                  <span class="text-default">{{ formatTimestamp(task.created_at) }}</span>
+                </span>
+                <span v-if="task.started_at">
+                  {{ $t("operations.tasks.detail.startedAt") }}:
+                  <span class="text-default">{{ formatTimestamp(task.started_at) }}</span>
+                </span>
+                <span v-if="task.finished_at">
+                  {{ $t("operations.tasks.detail.finishedAt") }}:
+                  <span class="text-default">{{ formatTimestamp(task.finished_at) }}</span>
+                </span>
+                <span>
+                  {{ $t("operations.tasks.detail.duration") }}:
+                  <span class="text-default tabular-nums">{{ formatDuration(task) }}</span>
+                </span>
+                <span v-if="task.parent_id">
+                  {{ $t("operations.tasks.detail.parent") }}:
+                  <UButton
+                    :to="localePath(`/operations/tasks/${task.parent_id}`)"
+                    variant="link"
+                    size="xs"
+                    class="font-mono px-0"
+                    :label="task.parent_id"
+                  />
+                </span>
+              </div>
+
+              <div v-if="task.status === 'running'" class="flex items-center gap-3">
+                <UProgress
+                  v-if="progressPercent(task) !== null"
+                  :model-value="progressPercent(task)!"
+                  size="sm"
+                  class="flex-1"
+                />
+                <span v-else class="flex items-center gap-2 text-xs text-muted">
+                  <LoadingSpinner class="size-3.5" />
+                  {{ progressMessage(task) ?? $t("operations.tasks.status.running") }}
+                </span>
+                <span
+                  v-if="progressPercent(task) !== null"
+                  class="text-xs text-muted tabular-nums w-10 text-end"
+                >
+                  {{ progressPercent(task) }}%
+                </span>
+              </div>
+              <p
+                v-if="
+                  task.status === 'running' &&
+                  progressPercent(task) !== null &&
+                  progressMessage(task)
+                "
+                class="text-xs text-muted"
+              >
+                {{ progressMessage(task) }}
+              </p>
+
+              <p
+                v-if="task.error"
+                class="text-xs text-error font-mono break-all whitespace-pre-wrap"
+              >
+                {{ task.error }}
+              </p>
+            </div>
+          </UPageCard>
+
+          <UPageCard
+            :title="$t('operations.tasks.detail.input')"
+            variant="subtle"
+            :ui="{ body: 'overflow-x-auto' }"
+          >
+            <pre class="text-xs font-mono whitespace-pre">{{ prettyJson(task.input) }}</pre>
+          </UPageCard>
+
+          <UPageCard
+            v-if="task.output !== undefined"
+            :title="$t('operations.tasks.detail.output')"
+            variant="subtle"
+            :ui="{ body: 'overflow-x-auto' }"
+          >
+            <pre class="text-xs font-mono whitespace-pre">{{ prettyJson(task.output) }}</pre>
+          </UPageCard>
+
+          <UPageCard :title="$t('operations.tasks.detail.children')" variant="subtle">
+            <DataState
+              :pending="childrenPending && children.length === 0"
+              :error="childrenError ? String(childrenError) : null"
+              :empty="children.length === 0"
+              :empty-text="$t('operations.tasks.detail.noChildren')"
+              :error-text="$t('operations.tasks.error')"
+              :retry-text="$t('common.retry')"
+              @retry="childrenReload()"
+            >
+              <div class="flex flex-col gap-2">
+                <UPageCard
+                  v-for="child in children"
+                  :key="child.id"
+                  variant="outline"
+                  :to="localePath(`/operations/tasks/${child.id}`)"
+                >
+                  <div class="flex flex-wrap sm:items-center justify-between gap-3">
+                    <div class="flex items-center gap-3 min-w-0">
+                      <UBadge
+                        :label="$t(`operations.tasks.status.${child.status}`)"
+                        :color="TASK_STATUS_COLORS[child.status]"
+                        variant="subtle"
+                      />
+                      <span class="font-mono text-sm truncate">{{ child.kind }}</span>
+                      <span class="text-muted text-xs font-mono">{{ child.id }}</span>
+                    </div>
+                    <span class="text-xs text-muted">{{ formatTimestamp(child.created_at) }}</span>
+                  </div>
+                </UPageCard>
+              </div>
+
+              <PagerBar
+                :has-prev="childrenHasPrev"
+                :has-next="childrenHasNext"
+                :pending="childrenPending && children.length === 0"
+                :prev-text="$t('common.prev')"
+                :next-text="$t('common.next')"
+                @prev="childrenLoadPrev()"
+                @next="childrenLoadNext()"
+              />
+            </DataState>
+          </UPageCard>
+        </div>
+      </DataState>
+    </div>
+  </AppPage>
+</template>

--- a/app/pages/operations/tasks/index.vue
+++ b/app/pages/operations/tasks/index.vue
@@ -1,20 +1,17 @@
 <script setup lang="ts">
 import type { SelectMenuItem } from "@nuxt/ui";
 import { useIntervalFn } from "@vueuse/core";
-import type {
-  ListTasksParams,
-  Task,
-  TaskDefinition,
-  TaskStatus,
-} from "~~/modules/aperture/runtime/types";
+import type { ListTasksParams, Task, TaskDefinition } from "~~/modules/aperture/runtime/types";
 import {
   TASK_STATUS_FILTERS,
   tasksParamsFromFilters,
   useTasksFilters,
 } from "~/composables/useTasksFilters";
+import { TASK_STATUS_COLORS, useTaskDisplay } from "~/composables/useTaskDisplay";
 
-const { t, te } = useI18n();
-const fmt = useFormatter();
+const { t } = useI18n();
+const localePath = useLocalePath();
+const { formatTimestamp, formatDuration, progressPercent, progressMessage } = useTaskDisplay();
 
 const filters = useTasksFilters();
 
@@ -40,15 +37,6 @@ const {
   () => params.value,
 );
 
-const STATUS_COLORS: Record<TaskStatus, "neutral" | "primary" | "success" | "error" | "warning"> = {
-  pending: "neutral",
-  running: "primary",
-  succeeded: "success",
-  failed: "error",
-  cancelled: "warning",
-  interrupted: "warning",
-};
-
 const statusItems = computed<SelectMenuItem[]>(() => [
   { label: t("operations.tasks.filters.statusAll"), value: undefined },
   ...TASK_STATUS_FILTERS.map((s) => ({
@@ -61,34 +49,6 @@ const kindItems = computed<SelectMenuItem[]>(() => [
   { label: t("operations.tasks.filters.kindAll"), value: undefined },
   ...(definitions.value ?? []).map((d) => ({ label: d.kind, value: d.kind })),
 ]);
-
-function formatTimestamp(ts: Temporal.Instant): string {
-  return fmt.date(ts, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
-}
-
-function formatDuration(task: Task): string {
-  if (!task.started_at) return t("operations.tasks.notStarted");
-  if (!task.finished_at) return t("operations.tasks.status.running");
-  return fmt.duration(task.finished_at.since(task.started_at), { fractionDigits: 1 });
-}
-
-function progressPercent(task: Task): number | null {
-  const p = task.progress;
-  if (!p?.total || p.done == null || p.total <= 0) return null;
-  return Math.min(100, Math.round((p.done / p.total) * 100));
-}
-
-function progressMessage(task: Task): string | null {
-  const msg = task.progress?.message;
-  if (!msg) return null;
-  return te(msg.key) ? t(msg.key, msg.args) : msg.key;
-}
 
 const hasActiveTasks = computed(() =>
   tasks.value.some((task) => task.status === "pending" || task.status === "running"),
@@ -152,13 +112,18 @@ onUnmounted(pause);
         @retry="reload()"
       >
         <div class="flex flex-col gap-2">
-          <UPageCard v-for="task in tasks" :key="task.id" variant="subtle">
+          <UPageCard
+            v-for="task in tasks"
+            :key="task.id"
+            variant="subtle"
+            :to="localePath(`/operations/tasks/${task.id}`)"
+          >
             <div class="flex flex-col gap-2">
               <div class="flex flex-wrap sm:items-center justify-between gap-3">
                 <div class="flex items-center gap-3 min-w-0">
                   <UBadge
                     :label="$t(`operations.tasks.status.${task.status}`)"
-                    :color="STATUS_COLORS[task.status]"
+                    :color="TASK_STATUS_COLORS[task.status]"
                     variant="subtle"
                   />
                   <span class="font-mono text-sm truncate">{{ task.kind }}</span>

--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -98,3 +98,98 @@ test("tasks list renders statuses and progress", async ({ page }) => {
   // The list asks for top-level tasks only by default.
   expect(taskRequests[0]).toContain("root=true");
 });
+
+const stubDetail = {
+  ...stubTasks[1],
+  output: undefined,
+};
+
+test("task detail renders and cancels", async ({ page }) => {
+  let cancelCalled = false;
+
+  await page.route("**/api/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/tasks/task-2") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(cancelCalled ? { ...stubDetail, status: "cancelled" } : stubDetail),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/tasks/task-2/cancel") {
+      cancelCalled = true;
+      await route.fulfill({ status: 202 });
+      return;
+    }
+
+    if (pathname === "/api/v1/tasks") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/task-definitions") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            kind: "rotate-certificate",
+            cancellable: true,
+            resumable: false,
+            input_schema: {},
+            output_schema: {},
+          },
+        ]),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.goto("/en/operations/tasks/task-2", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByRole("heading", { name: "rotate-certificate" })).toBeVisible();
+  await expect(page.getByText("40%")).toBeVisible();
+  await expect(page.getByText("Child tasks", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "Cancel task" }).click();
+  await expect(page.getByText("Cancelled")).toBeVisible({ timeout: 10_000 });
+});

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -239,6 +239,22 @@
         "interrupted": "Unterbrochen",
         "active": "Aktiv",
         "finished": "Beendet"
+      },
+      "cancel": "Aufgabe abbrechen",
+      "cancelRequested": "Abbruch angefordert.",
+      "cancelNotCancellable": "Diese Art von Aufgabe kann nicht abgebrochen werden.",
+      "cancelAlreadyFinished": "Diese Aufgabe ist bereits beendet.",
+      "cancelFailed": "Aufgabe konnte nicht abgebrochen werden.",
+      "detail": {
+        "createdAt": "Erstellt",
+        "startedAt": "Gestartet",
+        "finishedAt": "Beendet",
+        "duration": "Dauer",
+        "parent": "Übergeordnete Aufgabe",
+        "input": "Eingabe",
+        "output": "Ausgabe",
+        "children": "Untergeordnete Aufgaben",
+        "noChildren": "Keine untergeordneten Aufgaben."
       }
     },
     "schedules": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -239,6 +239,22 @@
         "interrupted": "Interrupted",
         "active": "Active",
         "finished": "Finished"
+      },
+      "cancel": "Cancel task",
+      "cancelRequested": "Cancellation requested.",
+      "cancelNotCancellable": "This task kind cannot be cancelled.",
+      "cancelAlreadyFinished": "This task has already finished.",
+      "cancelFailed": "Failed to cancel the task.",
+      "detail": {
+        "createdAt": "Created",
+        "startedAt": "Started",
+        "finishedAt": "Finished",
+        "duration": "Duration",
+        "parent": "Parent",
+        "input": "Input",
+        "output": "Output",
+        "children": "Child tasks",
+        "noChildren": "No child tasks."
       }
     },
     "schedules": {


### PR DESCRIPTION
Adds /operations/tasks/{id}: status header with timestamps and
duration, live progress, cancel button (respects the kind's
cancellable flag, handles 409 and 410), input and output JSON views,
a parent link, and a paginated child-task list. The list became
tasks/index.vue so the detail route sits beside it, and its cards now
link to the detail page. Shared status and progress helpers moved to
useTaskDisplay.