### PR TITLE
feat: schema-driven task input and output views

### DIFF
--- a/.github/workflows/aperture-sync.yaml
+++ b/.github/workflows/aperture-sync.yaml
@@ -59,7 +59,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           branch="aperture-regen/pr-${{ github.event.pull_request.number }}"
-          git add modules/aperture/openapi.json modules/aperture/runtime/generated.ts
+          git add modules/aperture/openapi.json modules/aperture/runtime/generated.ts modules/aperture/runtime/taskSchemaComponents.json
           if git diff --cached --quiet; then
             echo "no regenerated changes"
             exit 0

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ CHANGELOG.md
 # Generated files
 modules/aperture/openapi.json
 modules/aperture/runtime/generated.ts
+modules/aperture/runtime/taskSchemaComponents.json

--- a/app/components/SchemaValue.vue
+++ b/app/components/SchemaValue.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import {
+  pickOneOfBranch,
+  resolveRef,
+  schemaEntries,
+  type JsonSchemaLike,
+  type SchemaRow,
+} from "~/utils/schemaDisplay";
+import { formatValue } from "~/utils/logFields";
+
+const props = withDefaults(
+  defineProps<{
+    value: unknown;
+    schema?: JsonSchemaLike;
+    depth?: number;
+    emptyText?: string;
+  }>(),
+  { schema: undefined, depth: 0, emptyText: undefined },
+);
+
+const MAX_DEPTH = 8;
+
+const resolved = computed<JsonSchemaLike | undefined>(() => {
+  if (!props.schema) return undefined;
+  const base = resolveRef(props.schema);
+  if (!base) return undefined;
+  if (base.oneOf && typeof props.value === "object" && props.value !== null) {
+    const branch = pickOneOfBranch(base.oneOf, props.value);
+    if (branch) return branch;
+  }
+  return base;
+});
+
+const rows = computed(() => {
+  if (props.depth >= MAX_DEPTH || props.value === null) return undefined;
+  if (Array.isArray(props.value)) return undefined;
+  if (!resolved.value) return undefined;
+  return schemaEntries(resolved.value, props.value);
+});
+
+const isObject = (v: unknown): boolean => typeof v === "object" && v !== null && !Array.isArray(v);
+
+const isArray = Array.isArray;
+
+const rowSchema = (row: SchemaRow): JsonSchemaLike | undefined => row.schema;
+
+function scalarType(schema: JsonSchemaLike | undefined): "bool" | "enum" | "text" {
+  if (schema?.type === "boolean") return "bool";
+  if (schema?.enum?.length) return "enum";
+  return "text";
+}
+
+const rawJson = computed(() => {
+  try {
+    return JSON.stringify(props.value, null, 2) ?? "null";
+  } catch {
+    return formatValue(props.value);
+  }
+});
+</script>
+
+<template>
+  <div v-if="isArray(value)" class="flex flex-col gap-1">
+    <template v-if="depth < MAX_DEPTH">
+      <div
+        v-for="(item, i) in value as unknown[]"
+        :key="i"
+        class="border border-default rounded px-2 py-1"
+      >
+        <SchemaValue
+          :value="item"
+          :schema="resolved?.items"
+          :depth="depth + 1"
+          :empty-text="emptyText"
+        />
+      </div>
+    </template>
+    <pre v-else class="text-xs font-mono whitespace-pre-wrap">{{ rawJson }}</pre>
+  </div>
+
+  <div v-else-if="rows !== undefined && rows.length > 0" class="flex flex-col gap-1.5">
+    <div
+      v-for="row in rows"
+      :key="row.key"
+      class="flex max-sm:flex-col sm:items-baseline gap-x-2 gap-y-0.5"
+    >
+      <span :title="row.description" class="text-muted-foreground font-mono text-xs shrink-0">
+        {{ row.label }}:
+      </span>
+      <div class="min-w-0 text-xs font-mono">
+        <SchemaValue
+          v-if="isObject(row.value) || isArray(row.value)"
+          :value="row.value"
+          :schema="rowSchema(row)"
+          :depth="depth + 1"
+          :empty-text="emptyText"
+        />
+        <template v-else-if="row.value !== null">
+          <UBadge
+            v-if="scalarType(row.schema) === 'enum'"
+            :label="formatValue(row.value)"
+            variant="subtle"
+          />
+          <UIcon
+            v-else-if="scalarType(row.schema) === 'bool' && row.value === true"
+            name="i-lucide-check"
+            class="size-3.5 text-success"
+          />
+          <UIcon
+            v-else-if="scalarType(row.schema) === 'bool'"
+            name="i-lucide-x"
+            class="size-3.5 text-error"
+          />
+          <span v-else class="break-all tabular-nums">{{ formatValue(row.value) }}</span>
+        </template>
+        <span v-else class="text-muted-foreground">null</span>
+      </div>
+    </div>
+  </div>
+
+  <span v-else-if="rows !== undefined && rows.length === 0" class="text-muted-foreground text-xs">
+    {{ emptyText }}
+  </span>
+
+  <span v-else-if="value === null" class="text-muted-foreground text-xs">null</span>
+
+  <pre v-else-if="typeof value === 'object'" class="text-xs font-mono whitespace-pre-wrap">{{
+    rawJson
+  }}</pre>
+
+  <template v-else>
+    <UBadge v-if="scalarType(resolved) === 'enum'" :label="formatValue(value)" variant="subtle" />
+    <UIcon
+      v-else-if="scalarType(resolved) === 'bool' && value === true"
+      name="i-lucide-check"
+      class="size-3.5 text-success"
+    />
+    <UIcon
+      v-else-if="scalarType(resolved) === 'bool'"
+      name="i-lucide-x"
+      class="size-3.5 text-error"
+    />
+    <span v-else class="break-all tabular-nums">{{ formatValue(value) }}</span>
+  </template>
+</template>

--- a/app/pages/operations/tasks/[id].vue
+++ b/app/pages/operations/tasks/[id].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useIntervalFn } from "@vueuse/core";
 import type { ListTasksParams, Task, TaskDefinition } from "~~/modules/aperture/runtime/types";
+import type { JsonSchemaLike } from "~/utils/schemaDisplay";
 import { TASK_STATUS_COLORS, useTaskDisplay } from "~/composables/useTaskDisplay";
 
 const { t } = useI18n();
@@ -24,6 +25,13 @@ const { data: definitionsData } = useAsyncData<TaskDefinition[]>(
 const definition = computed<TaskDefinition | undefined>(() =>
   (definitionsData.value ?? []).find((d) => d.kind === task.value?.kind),
 );
+
+function asSchema(value: unknown): JsonSchemaLike | undefined {
+  return typeof value === "object" && value !== null ? (value as JsonSchemaLike) : undefined;
+}
+
+const inputSchema = computed(() => asSchema(definition.value?.input_schema));
+const outputSchema = computed(() => asSchema(definition.value?.output_schema));
 
 async function load() {
   loading.value = true;
@@ -79,6 +87,9 @@ async function cancel() {
 function prettyJson(value: unknown): string {
   return JSON.stringify(value ?? null, null, 2);
 }
+
+const showRawInput = ref(false);
+const showRawOutput = ref(false);
 
 const {
   items: children,
@@ -208,21 +219,54 @@ const {
             </div>
           </UPageCard>
 
-          <UPageCard
-            :title="$t('operations.tasks.detail.input')"
-            variant="subtle"
-            :ui="{ body: 'overflow-x-auto' }"
-          >
-            <pre class="text-xs font-mono whitespace-pre">{{ prettyJson(task.input) }}</pre>
+          <UPageCard variant="subtle" :ui="{ body: 'overflow-x-auto' }">
+            <template #title>
+              <div class="flex items-center justify-between gap-2 w-full">
+                <span>{{ $t("operations.tasks.detail.input") }}</span>
+                <UButton
+                  size="xs"
+                  color="neutral"
+                  variant="ghost"
+                  :icon="showRawInput ? 'i-lucide-braces' : 'i-lucide-file-code'"
+                  :label="$t('common.rawJson')"
+                  @click="showRawInput = !showRawInput"
+                />
+              </div>
+            </template>
+            <SchemaValue
+              v-if="!showRawInput"
+              :value="task.input"
+              :schema="inputSchema"
+              :empty-text="$t('common.noParameters')"
+            />
+            <pre v-else class="text-xs font-mono whitespace-pre">{{ prettyJson(task.input) }}</pre>
           </UPageCard>
 
           <UPageCard
             v-if="task.output !== undefined"
-            :title="$t('operations.tasks.detail.output')"
             variant="subtle"
             :ui="{ body: 'overflow-x-auto' }"
           >
-            <pre class="text-xs font-mono whitespace-pre">{{ prettyJson(task.output) }}</pre>
+            <template #title>
+              <div class="flex items-center justify-between gap-2 w-full">
+                <span>{{ $t("operations.tasks.detail.output") }}</span>
+                <UButton
+                  size="xs"
+                  color="neutral"
+                  variant="ghost"
+                  :icon="showRawOutput ? 'i-lucide-braces' : 'i-lucide-file-code'"
+                  :label="$t('common.rawJson')"
+                  @click="showRawOutput = !showRawOutput"
+                />
+              </div>
+            </template>
+            <SchemaValue
+              v-if="!showRawOutput"
+              :value="task.output"
+              :schema="outputSchema"
+              :empty-text="$t('common.noParameters')"
+            />
+            <pre v-else class="text-xs font-mono whitespace-pre">{{ prettyJson(task.output) }}</pre>
           </UPageCard>
 
           <UPageCard :title="$t('operations.tasks.detail.children')" variant="subtle">

--- a/app/utils/schemaDisplay.ts
+++ b/app/utils/schemaDisplay.ts
@@ -1,0 +1,120 @@
+import componentsJson from "~~/modules/aperture/runtime/taskSchemaComponents.json";
+
+export interface JsonSchemaLike {
+  $ref?: string;
+  type?: string | string[];
+  title?: string;
+  description?: string;
+  enum?: unknown[];
+  oneOf?: JsonSchemaLike[];
+  properties?: Record<string, JsonSchemaLike>;
+  items?: JsonSchemaLike;
+  required?: string[];
+  format?: string;
+  [key: string]: unknown;
+}
+
+export type SchemaComponents = Record<string, JsonSchemaLike>;
+
+const taskSchemaComponents = componentsJson as SchemaComponents;
+
+const REF_PREFIX = "#/components/schemas/";
+
+/**
+ * Resolves `$ref` pointers against the bundled spec components. Sibling
+ * keywords next to `$ref` (e.g. a `description`) win over the target.
+ * Returns undefined for refs the bundle does not know.
+ */
+export function resolveRef(
+  schema: JsonSchemaLike,
+  components: SchemaComponents = taskSchemaComponents,
+): JsonSchemaLike | undefined {
+  if (!schema.$ref) return schema;
+  const name = schema.$ref.startsWith(REF_PREFIX) ? schema.$ref.slice(REF_PREFIX.length) : null;
+  const target = name ? components[name] : undefined;
+  if (!target) return undefined;
+  const { $ref: _, ...siblings } = schema;
+  return { ...resolveRef(target, components), ...siblings };
+}
+
+/**
+ * Picks the `oneOf` branch the given value matches. Prefers a literal
+ * discriminator (`type`/`kind` enum constant), then falls back to scoring
+ * branches by how many required properties the value carries.
+ */
+export function pickOneOfBranch(
+  branches: JsonSchemaLike[],
+  value: unknown,
+): JsonSchemaLike | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+
+  for (const branch of branches) {
+    const tag = tagValue(branch);
+    if (tag && recordMatchesTag(record, tag)) return branch;
+  }
+
+  let best: { branch: JsonSchemaLike; score: number } | undefined;
+  for (const branch of branches) {
+    const required = (branch.required ?? []).filter((k) => k in record);
+    if (required.length === 0) continue;
+    const total = branch.required?.length ?? 0;
+    const score = required.length / total;
+    if (!best || score > best.score) best = { branch, score };
+  }
+  return best?.branch;
+}
+
+function tagValue(branch: JsonSchemaLike): [string, unknown] | undefined {
+  for (const key of ["type", "kind"]) {
+    const prop = branch.properties?.[key];
+    if (prop?.enum?.length === 1) return [key, prop.enum[0]];
+  }
+  return undefined;
+}
+
+function recordMatchesTag(record: Record<string, unknown>, [key, expected]: [string, unknown]) {
+  return key in record && record[key] === expected;
+}
+
+export interface SchemaRow {
+  key: string;
+  label: string;
+  description?: string;
+  value: unknown;
+  schema?: JsonSchemaLike;
+}
+
+/**
+ * Builds ordered display rows for an object value against its schema. Rows
+ * follow schema property order; value keys the schema does not describe are
+ * appended with no schema so nothing is silently hidden.
+ */
+export function schemaEntries(
+  schema: JsonSchemaLike,
+  value: unknown,
+  components?: SchemaComponents,
+): SchemaRow[] | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+
+  const rows: SchemaRow[] = [];
+  const seen = new Set<string>();
+  for (const [key, prop] of Object.entries(schema.properties ?? {})) {
+    if (!(key in record)) continue;
+    seen.add(key);
+    const resolved = resolveRef(prop, components);
+    rows.push({
+      key,
+      label: resolved?.title ?? key,
+      description: resolved?.description,
+      value: record[key],
+      schema: resolved,
+    });
+  }
+  for (const key of Object.keys(record)) {
+    if (seen.has(key)) continue;
+    rows.push({ key, label: key, value: record[key] });
+  }
+  return rows;
+}

--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -104,6 +104,41 @@ const stubDetail = {
   output: undefined,
 };
 
+const ociInput = {
+  key: "spectra",
+  source: {
+    type: "oci",
+    reference: "ghcr.io/stargrid-systems/spectra:1",
+    media_type: "application/vnd.oci.image.layer.v1.tar",
+  },
+};
+
+const downloadDefinition = {
+  kind: "rotate-certificate",
+  cancellable: true,
+  resumable: false,
+  input_schema: {
+    type: "object",
+    properties: {
+      key: { type: "string", description: "Logical key to record the artifact under." },
+      source: {
+        oneOf: [
+          {
+            type: "object",
+            required: ["reference", "media_type", "type"],
+            properties: {
+              reference: { type: "string", description: "The image reference." },
+              media_type: { type: "string" },
+              type: { type: "string", enum: ["oci"] },
+            },
+          },
+        ],
+      },
+    },
+  },
+  output_schema: {},
+};
+
 test("task detail renders and cancels", async ({ page }) => {
   let cancelCalled = false;
 
@@ -140,7 +175,11 @@ test("task detail renders and cancels", async ({ page }) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify(cancelCalled ? { ...stubDetail, status: "cancelled" } : stubDetail),
+        body: JSON.stringify(
+          cancelCalled
+            ? { ...stubDetail, status: "cancelled", input: ociInput }
+            : { ...stubDetail, input: ociInput },
+        ),
       });
       return;
     }
@@ -164,15 +203,7 @@ test("task detail renders and cancels", async ({ page }) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify([
-          {
-            kind: "rotate-certificate",
-            cancellable: true,
-            resumable: false,
-            input_schema: {},
-            output_schema: {},
-          },
-        ]),
+        body: JSON.stringify([downloadDefinition]),
       });
       return;
     }
@@ -189,6 +220,20 @@ test("task detail renders and cancels", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "rotate-certificate" })).toBeVisible();
   await expect(page.getByText("40%")).toBeVisible();
   await expect(page.getByText("Child tasks", { exact: true })).toBeVisible();
+
+  // Schema-driven input view shows labeled fields from the definition schema.
+  await expect(page.getByTitle("Logical key to record the artifact under.")).toBeVisible();
+  await expect(page.getByTitle("The image reference.")).toBeVisible();
+  await expect(page.getByText("ghcr.io/stargrid-systems/spectra:1")).toBeVisible();
+
+  // The raw toggle switches to plain JSON.
+  await page
+    .locator("section, div")
+    .filter({ hasText: "Input" })
+    .getByRole("button", { name: "Raw JSON" })
+    .first()
+    .click();
+  await expect(page.getByText('"key": "spectra"')).toBeVisible();
 
   await page.getByRole("button", { name: "Cancel task" }).click();
   await expect(page.getByText("Cancelled")).toBeVisible({ timeout: 10_000 });

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -12,8 +12,10 @@
     "create": "Erstellen",
     "done": "Fertig",
     "next": "Weiter",
+    "noParameters": "Keine Parameter.",
     "notImplemented": "Noch nicht implementiert.",
     "prev": "Zurück",
+    "rawJson": "JSON-Rohdaten",
     "retry": "Erneut versuchen"
   },
   "auth": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -12,8 +12,10 @@
     "create": "Create",
     "done": "Done",
     "next": "Next",
+    "noParameters": "No parameters.",
     "notImplemented": "Not implemented yet.",
     "prev": "Previous",
+    "rawJson": "Raw JSON",
     "retry": "Retry"
   },
   "auth": {

--- a/modules/aperture/runtime/taskSchemaComponents.json
+++ b/modules/aperture/runtime/taskSchemaComponents.json
@@ -1,0 +1,1143 @@
+{
+  "ActorId": {
+    "type": "string",
+    "description": "Primary key of a row in the `actors` table.\n\nUsed wherever an actor is referenced: `users.actor_id`,\n`sessions.actor_id`, `api_keys.actor_id`, `tasks.initiator_id`."
+  },
+  "ApiKeyId": {
+    "type": "string",
+    "description": "Primary key of a row in the `api_keys` table."
+  },
+  "ApiKeyResponse": {
+    "type": "object",
+    "required": [
+      "id",
+      "name",
+      "prefix"
+    ],
+    "properties": {
+      "id": {
+        "$ref": "#/components/schemas/ApiKeyId"
+      },
+      "last_used_at": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "format": "date-time"
+      },
+      "name": {
+        "type": "string"
+      },
+      "prefix": {
+        "type": "string"
+      }
+    }
+  },
+  "ArtifactKey": {
+    "type": "string",
+    "description": "Logical artifact identifier, for example `spectra` or `tls_server-cert`.",
+    "maxLength": 1024
+  },
+  "ArtifactSummaryResponse": {
+    "type": "object",
+    "description": "A distinct artifact key with its newest version, for `GET\n/api/v1/artifacts`.",
+    "required": [
+      "key",
+      "version_count",
+      "source",
+      "digest",
+      "size_bytes",
+      "downloaded_at"
+    ],
+    "properties": {
+      "digest": {
+        "$ref": "#/components/schemas/Digest",
+        "description": "Content digest of the newest version."
+      },
+      "downloaded_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "When the newest version was downloaded."
+      },
+      "key": {
+        "type": "string",
+        "description": "Logical artifact key."
+      },
+      "size_bytes": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Stored blob size of the newest version, in bytes.",
+        "minimum": 0
+      },
+      "source": {
+        "type": "string",
+        "description": "Where the newest version came from."
+      },
+      "version": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "description": "Human-readable version of the newest version, if known."
+      },
+      "version_count": {
+        "type": "integer",
+        "format": "int64",
+        "description": "How many versions of this key are stored.",
+        "minimum": 0
+      }
+    }
+  },
+  "ArtifactVersionResponse": {
+    "type": "object",
+    "description": "One stored version of an artifact.",
+    "required": [
+      "key",
+      "digest",
+      "source",
+      "size_bytes",
+      "downloaded_at"
+    ],
+    "properties": {
+      "digest": {
+        "$ref": "#/components/schemas/Digest",
+        "description": "Content digest of the stored blob."
+      },
+      "downloaded_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "When this version was downloaded."
+      },
+      "key": {
+        "type": "string",
+        "description": "Logical artifact key."
+      },
+      "media_type": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/components/schemas/MediaType",
+            "description": "OCI media type, if applicable."
+          }
+        ]
+      },
+      "size_bytes": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Stored blob size in bytes.",
+        "minimum": 0
+      },
+      "source": {
+        "type": "string",
+        "description": "Where this version came from."
+      },
+      "verified_at": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "format": "date-time",
+        "description": "When this version was last verified, if ever."
+      },
+      "version": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "description": "Human-readable version, if known."
+      }
+    }
+  },
+  "BootResponse": {
+    "type": "object",
+    "description": "One boot session observed in the log store, returned by\n`GET /api/v1/logs/boots`.",
+    "required": [
+      "boot_id",
+      "first_seen",
+      "last_seen",
+      "event_count",
+      "is_current"
+    ],
+    "properties": {
+      "boot_id": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Unique boot id (UUID)."
+      },
+      "event_count": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Number of events recorded so far in this boot.",
+        "minimum": 0
+      },
+      "first_seen": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Timestamp of the earliest event in this boot."
+      },
+      "is_current": {
+        "type": "boolean",
+        "description": "True if this is the currently running gateway boot."
+      },
+      "last_seen": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Timestamp of the latest event in this boot."
+      }
+    }
+  },
+  "ChangePasswordRequest": {
+    "type": "object",
+    "required": [
+      "current_password",
+      "new_password"
+    ],
+    "properties": {
+      "current_password": {
+        "$ref": "#/components/schemas/Password"
+      },
+      "new_password": {
+        "$ref": "#/components/schemas/Password"
+      }
+    }
+  },
+  "CreateApiKeyRequest": {
+    "type": "object",
+    "required": [
+      "name"
+    ],
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "role": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/components/schemas/Role",
+            "description": "Optional role to assign to this key's casbin subject."
+          }
+        ]
+      }
+    }
+  },
+  "CreateApiKeyResponse": {
+    "type": "object",
+    "required": [
+      "id",
+      "name",
+      "prefix",
+      "key"
+    ],
+    "properties": {
+      "id": {
+        "$ref": "#/components/schemas/ApiKeyId"
+      },
+      "key": {
+        "$ref": "#/components/schemas/RawApiKey",
+        "description": "The full key. Only visible at creation time."
+      },
+      "name": {
+        "type": "string"
+      },
+      "prefix": {
+        "type": "string"
+      }
+    }
+  },
+  "CreateTaskInput": {
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "kind",
+          "input"
+        ],
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/DownloadInput"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "download"
+            ]
+          }
+        }
+      },
+      {
+        "type": "object",
+        "required": [
+          "kind",
+          "input"
+        ],
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/RotateCertificateInput"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "rotate-certificate"
+            ]
+          }
+        }
+      }
+    ],
+    "discriminator": {
+      "propertyName": "kind"
+    }
+  },
+  "CreateTaskRequest": {
+    "type": "object",
+    "description": "Body for `POST /api/v1/tasks`.",
+    "required": [
+      "kind",
+      "input"
+    ],
+    "properties": {
+      "input": {
+        "description": "The task input, matching the kind's input schema."
+      },
+      "kind": {
+        "type": "string",
+        "description": "The kind of task to create."
+      }
+    }
+  },
+  "CreateTaskScheduleRequest": {
+    "type": "object",
+    "description": "Body for `POST /api/v1/task-schedules`.",
+    "required": [
+      "kind",
+      "input",
+      "interval"
+    ],
+    "properties": {
+      "input": {},
+      "interval": {
+        "$ref": "#/components/schemas/Interval"
+      },
+      "kind": {
+        "type": "string"
+      }
+    }
+  },
+  "CreateUserRequest": {
+    "type": "object",
+    "required": [
+      "username",
+      "password"
+    ],
+    "properties": {
+      "password": {
+        "$ref": "#/components/schemas/Password"
+      },
+      "role": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/components/schemas/Role"
+          }
+        ]
+      },
+      "username": {
+        "$ref": "#/components/schemas/Username"
+      }
+    }
+  },
+  "CurrentActorResponse": {
+    "type": "object",
+    "required": [
+      "actor_id",
+      "display_name",
+      "roles",
+      "must_change_password"
+    ],
+    "properties": {
+      "actor_id": {
+        "$ref": "#/components/schemas/ActorId"
+      },
+      "display_name": {
+        "type": "string"
+      },
+      "must_change_password": {
+        "type": "boolean"
+      },
+      "roles": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Role"
+        }
+      },
+      "user_id": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/components/schemas/UserId"
+          }
+        ]
+      },
+      "username": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    }
+  },
+  "Digest": {
+    "type": "string",
+    "description": "Content digest, e.g. `sha256:hex`."
+  },
+  "DownloadInput": {
+    "type": "object",
+    "description": "Input for a download task: what to fetch and where from.",
+    "required": [
+      "key",
+      "source"
+    ],
+    "properties": {
+      "key": {
+        "$ref": "#/components/schemas/ArtifactKey",
+        "description": "Logical key to record the artifact under."
+      },
+      "source": {
+        "$ref": "#/components/schemas/DownloadSource",
+        "description": "Where and how to fetch it from."
+      }
+    }
+  },
+  "DownloadOutput": {
+    "type": "object",
+    "description": "Output of a download task: the stored version that resulted.",
+    "required": [
+      "digest",
+      "size_bytes"
+    ],
+    "properties": {
+      "digest": {
+        "$ref": "#/components/schemas/Digest",
+        "description": "Content digest of the stored blob."
+      },
+      "size_bytes": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Stored blob size in bytes.",
+        "minimum": 0
+      },
+      "version": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "description": "Human-readable version, if known."
+      }
+    }
+  },
+  "DownloadSource": {
+    "oneOf": [
+      {
+        "type": "object",
+        "description": "A layer of an OCI image.",
+        "required": [
+          "reference",
+          "media_type",
+          "type"
+        ],
+        "properties": {
+          "media_type": {
+            "$ref": "#/components/schemas/MediaType",
+            "description": "The media type of the layer to pull."
+          },
+          "reference": {
+            "type": "string",
+            "description": "The image reference, for example `ghcr.io/org/image:tag`."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "oci"
+            ]
+          }
+        }
+      }
+    ],
+    "description": "Where a download fetches from."
+  },
+  "EventId": {
+    "type": "string",
+    "description": "Primary key of a row in the `log_events` table."
+  },
+  "Interval": {
+    "type": "string",
+    "format": "duration",
+    "description": "A strictly-positive span of time, stored as a whole number of microseconds.\n\nOn the wire an interval is an ISO 8601 duration such as `PT5M`. Jiff also\naccepts its friendlier form (`5m`) on input.",
+    "example": "PT5M"
+  },
+  "JsonQueryString": {
+    "type": "string",
+    "description": "A structured field filter passed as a string-encoded JSON object in a\nquery parameter, e.g. `{\"key\":\"value\"}`.\n\nThe raw string is parsed into key-value pairs during deserialization.",
+    "example": "{\"status\":\"ok\"}"
+  },
+  "LevelResponse": {
+    "type": "string",
+    "description": "Severity level of a log event or span.",
+    "enum": [
+      "trace",
+      "debug",
+      "info",
+      "warn",
+      "error"
+    ]
+  },
+  "LogEventResponse": {
+    "type": "object",
+    "description": "A single log event, returned by `GET /api/v1/logs`.",
+    "required": [
+      "id",
+      "level",
+      "target",
+      "timestamp",
+      "boot_id",
+      "fields"
+    ],
+    "properties": {
+      "boot_id": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Boot session this event belongs to, if known."
+      },
+      "fields": {
+        "type": "object",
+        "description": "Structured fields as a JSON object, if any.",
+        "additionalProperties": {},
+        "propertyNames": {
+          "type": "string"
+        }
+      },
+      "file": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "description": "Source file, if available."
+      },
+      "id": {
+        "$ref": "#/components/schemas/EventId",
+        "description": "Event id."
+      },
+      "level": {
+        "$ref": "#/components/schemas/LevelResponse",
+        "description": "Severity level."
+      },
+      "line": {
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "int32",
+        "description": "Source line, if available.",
+        "minimum": 0
+      },
+      "message": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "description": "Human-readable message, if any."
+      },
+      "span_id": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/components/schemas/SpanId",
+            "description": "Span this event belongs to, if any."
+          }
+        ]
+      },
+      "target": {
+        "type": "string",
+        "description": "Module path that emitted the event."
+      },
+      "timestamp": {
+        "type": "string",
+        "format": "date-time",
+        "description": "When the event was emitted."
+      }
+    }
+  },
+  "LogSpanDetailResponse": {
+    "allOf": [
+      {
+        "$ref": "#/components/schemas/LogSpanResponse"
+      },
+      {
+        "type": "object",
+        "required": [
+          "events"
+        ],
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LogEventResponse"
+            },
+            "description": "Events belonging to this span, ordered by timestamp."
+          }
+        }
+      }
+    ],
+    "description": "A span with its child events, returned by `GET /api/v1/logs/spans/{id}`."
+  },
+  "LogSpanResponse": {
+    "type": "object",
+    "description": "A tracing span, returned by `GET /api/v1/logs/spans`.",
+    "required": [
+      "id",
+      "name",
+      "level",
+      "target",
+      "started_at",
+      "fields"
+    ],
+    "properties": {
+      "ended_at": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "format": "date-time",
+        "description": "When the span ended, if it did."
+      },
+      "fields": {
+        "type": "object",
+        "description": "Span fields as a JSON object, if any.",
+        "additionalProperties": {},
+        "propertyNames": {
+          "type": "string"
+        }
+      },
+      "file": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "description": "Source file, if available."
+      },
+      "id": {
+        "$ref": "#/components/schemas/SpanId",
+        "description": "Span id."
+      },
+      "level": {
+        "$ref": "#/components/schemas/LevelResponse",
+        "description": "Severity level."
+      },
+      "line": {
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "int32",
+        "description": "Source line, if available.",
+        "minimum": 0
+      },
+      "name": {
+        "type": "string",
+        "description": "Span name."
+      },
+      "parent_id": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/components/schemas/SpanId",
+            "description": "Parent span id, if any."
+          }
+        ]
+      },
+      "started_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "When the span started."
+      },
+      "target": {
+        "type": "string",
+        "description": "Module path that created the span."
+      }
+    }
+  },
+  "LoginRequest": {
+    "type": "object",
+    "required": [
+      "username",
+      "password"
+    ],
+    "properties": {
+      "password": {
+        "$ref": "#/components/schemas/Password"
+      },
+      "username": {
+        "$ref": "#/components/schemas/Username"
+      }
+    }
+  },
+  "LoginResponse": {
+    "type": "object",
+    "required": [
+      "must_change_password"
+    ],
+    "properties": {
+      "must_change_password": {
+        "type": "boolean"
+      }
+    }
+  },
+  "MediaType": {
+    "type": "string",
+    "description": "A bare 'type/subtype' media type with no parameters."
+  },
+  "OrderParam": {
+    "type": "string",
+    "description": "Sort direction shared by list endpoints.",
+    "enum": [
+      "asc",
+      "desc"
+    ]
+  },
+  "Password": {
+    "type": "string",
+    "description": "A plaintext password. Redacts in Debug output to avoid accidental leakage.\n\nUnlike [`Username`](crate::Username), `Password` does NOT validate on\nconstruction or deserialization. This is deliberate: the login handler must\naccept any password string (even one below the minimum length) so the\nrequest reaches the handler body where the rate limiter is consulted.\nValidating at deserialization would let an attacker bypass rate limiting\nby sending short passwords (they would be rejected with a 400 before the\nhandler runs). Password validation happens in\n[`AuthHandle`](crate::AuthHandle) methods (`create_user`,\n`change_password`, `setup_admin`) instead."
+  },
+  "ProgressMessageResponse": {
+    "type": "object",
+    "description": "A localizable progress message: a translation key and its arguments.",
+    "required": [
+      "key",
+      "args"
+    ],
+    "properties": {
+      "args": {
+        "type": "object",
+        "description": "Arguments to interpolate into the resolved message.",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        }
+      },
+      "key": {
+        "type": "string",
+        "description": "Translation key for the current step."
+      }
+    }
+  },
+  "ProgressResponse": {
+    "type": "object",
+    "description": "Live progress of a running task.",
+    "properties": {
+      "done": {
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "int64",
+        "description": "Units of work completed so far.",
+        "minimum": 0
+      },
+      "message": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/components/schemas/ProgressMessageResponse",
+            "description": "A localizable description of the current step."
+          }
+        ]
+      },
+      "total": {
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "int64",
+        "description": "Total units of work expected, if known.",
+        "minimum": 0
+      }
+    }
+  },
+  "RawApiKey": {
+    "type": "string",
+    "description": "A raw API key. Redacts in Debug output."
+  },
+  "Role": {
+    "type": "string",
+    "description": "A built-in role. Stored as its lowercase name in casbin grouping rules.",
+    "enum": [
+      "admin",
+      "operator",
+      "viewer"
+    ]
+  },
+  "RotateCertificateInput": {
+    "type": "object",
+    "description": "Rotation takes no parameters (identity-preserving)."
+  },
+  "RotateCertificateOutput": {
+    "type": "object",
+    "required": [
+      "rotated"
+    ],
+    "properties": {
+      "rotated": {
+        "type": "boolean",
+        "description": "Whether the leaf was actually re-issued."
+      }
+    }
+  },
+  "SettingResponse": {
+    "type": "object",
+    "description": "One setting key and its current value.",
+    "required": [
+      "key",
+      "value"
+    ],
+    "properties": {
+      "key": {
+        "type": "string"
+      },
+      "value": {}
+    }
+  },
+  "SetupRequest": {
+    "type": "object",
+    "required": [
+      "username",
+      "password"
+    ],
+    "properties": {
+      "password": {
+        "$ref": "#/components/schemas/Password"
+      },
+      "username": {
+        "$ref": "#/components/schemas/Username"
+      }
+    }
+  },
+  "SetupStatusResponse": {
+    "type": "object",
+    "required": [
+      "setup_required"
+    ],
+    "properties": {
+      "setup_required": {
+        "type": "boolean"
+      }
+    }
+  },
+  "SpanId": {
+    "type": "string",
+    "description": "Primary key of a row in the `log_spans` table."
+  },
+  "TaskDefinitionResponse": {
+    "type": "object",
+    "description": "A registered task kind, with its capabilities and JSON Schemas.",
+    "required": [
+      "kind",
+      "cancellable",
+      "resumable",
+      "input_schema",
+      "output_schema"
+    ],
+    "properties": {
+      "cancellable": {
+        "type": "boolean",
+        "description": "Whether the kind can be cancelled."
+      },
+      "input_schema": {
+        "description": "JSON Schema of the kind's input."
+      },
+      "kind": {
+        "type": "string",
+        "description": "The kind string."
+      },
+      "output_schema": {
+        "description": "JSON Schema of the kind's output."
+      },
+      "resumable": {
+        "type": "boolean",
+        "description": "Whether the kind is safe to interrupt across a restart."
+      }
+    }
+  },
+  "TaskId": {
+    "type": "string",
+    "description": "Primary key of a row in the `tasks` table."
+  },
+  "TaskResponse": {
+    "type": "object",
+    "description": "One task invocation, returned by the task endpoints.",
+    "required": [
+      "id",
+      "kind",
+      "status",
+      "input",
+      "created_at"
+    ],
+    "properties": {
+      "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "When the invocation was recorded."
+      },
+      "error": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "description": "Failure detail, if any."
+      },
+      "finished_at": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "format": "date-time",
+        "description": "When it finished, if it did."
+      },
+      "id": {
+        "$ref": "#/components/schemas/TaskId",
+        "description": "Invocation id."
+      },
+      "input": {
+        "description": "The input the task was created with."
+      },
+      "kind": {
+        "type": "string",
+        "description": "The kind of task."
+      },
+      "output": {
+        "description": "The output, once the task succeeds."
+      },
+      "parent_id": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/components/schemas/TaskId",
+            "description": "The parent invocation, if this task was spawned by another."
+          }
+        ]
+      },
+      "progress": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/components/schemas/ProgressResponse",
+            "description": "Live progress, present only while running."
+          }
+        ]
+      },
+      "started_at": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "format": "date-time",
+        "description": "When it started running, if it did."
+      },
+      "status": {
+        "$ref": "#/components/schemas/TaskStatusResponse",
+        "description": "Lifecycle state."
+      }
+    }
+  },
+  "TaskScheduleId": {
+    "type": "string",
+    "description": "Primary key of a row in the `task_schedules` table."
+  },
+  "TaskScheduleResponse": {
+    "type": "object",
+    "required": [
+      "id",
+      "kind",
+      "input",
+      "interval",
+      "next_run_at",
+      "enabled",
+      "created_at"
+    ],
+    "properties": {
+      "created_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "enabled": {
+        "type": "boolean"
+      },
+      "id": {
+        "$ref": "#/components/schemas/TaskScheduleId"
+      },
+      "input": {},
+      "interval": {
+        "$ref": "#/components/schemas/Interval"
+      },
+      "kind": {
+        "type": "string"
+      },
+      "last_run_at": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "format": "date-time"
+      },
+      "last_task_id": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/components/schemas/TaskId"
+          }
+        ]
+      },
+      "next_run_at": {
+        "type": "string",
+        "format": "date-time"
+      }
+    }
+  },
+  "TaskStatusParam": {
+    "type": "string",
+    "description": "Filter for task status, including the `active` and `finished` groups.",
+    "enum": [
+      "active",
+      "finished",
+      "pending",
+      "running",
+      "succeeded",
+      "failed",
+      "cancelled",
+      "interrupted"
+    ]
+  },
+  "TaskStatusResponse": {
+    "type": "string",
+    "description": "Lifecycle state of a task invocation.",
+    "enum": [
+      "pending",
+      "running",
+      "succeeded",
+      "failed",
+      "cancelled",
+      "interrupted"
+    ]
+  },
+  "UpdateSettingRequest": {
+    "type": "object",
+    "description": "Body for `PUT /api/v1/settings/{key}`.",
+    "required": [
+      "value"
+    ],
+    "properties": {
+      "value": {}
+    }
+  },
+  "UpdateTaskScheduleRequest": {
+    "type": "object",
+    "description": "Body for `PATCH /api/v1/task-schedules/{id}`.",
+    "properties": {
+      "enabled": {
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
+      "interval": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/components/schemas/Interval"
+          }
+        ]
+      }
+    }
+  },
+  "UserId": {
+    "type": "string",
+    "description": "Primary key of a row in the `users` table."
+  },
+  "UserResponse": {
+    "type": "object",
+    "required": [
+      "id",
+      "actor_id",
+      "username",
+      "must_change_password"
+    ],
+    "properties": {
+      "actor_id": {
+        "$ref": "#/components/schemas/ActorId"
+      },
+      "id": {
+        "$ref": "#/components/schemas/UserId"
+      },
+      "must_change_password": {
+        "type": "boolean"
+      },
+      "username": {
+        "type": "string"
+      }
+    }
+  },
+  "Username": {
+    "type": "string",
+    "description": "A login name that is guaranteed valid by construction.\n\nAllowed characters are ASCII letters, digits, and `_`, `-`, `.`. The length\nis bounded to 1..=64 characters. Because validation runs in [`TryFrom`] (and\ntherefore during deserialization), a request body with an invalid username\nis rejected at the extractor boundary with a `400` before any handler runs."
+  },
+  "VersionResponse": {
+    "type": "object",
+    "description": "Version information returned by `GET /api/v1/version`.",
+    "required": [
+      "aperture",
+      "boot_id"
+    ],
+    "properties": {
+      "aperture": {
+        "type": "string",
+        "description": "Version of the Aperture gateway."
+      },
+      "boot_id": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Unique id of this gateway boot session."
+      }
+    }
+  },
+  "VersionSortParam": {
+    "type": "string",
+    "description": "Field a version listing is sorted by.",
+    "enum": [
+      "downloaded_at",
+      "size_bytes"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "openapi:generate": "openapi-typescript modules/aperture/openapi.json -o modules/aperture/runtime/generated.ts",
+    "openapi:generate": "openapi-typescript modules/aperture/openapi.json -o modules/aperture/runtime/generated.ts && node scripts/extract-task-schema-components.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint:ci": "eslint . --format @microsoft/eslint-formatter-sarif -o eslint.sarif",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "openapi:generate": "openapi-typescript modules/aperture/openapi.json -o modules/aperture/runtime/generated.ts && node scripts/extract-task-schema-components.mjs",
+    "openapi:generate": "openapi-typescript modules/aperture/openapi.json -o modules/aperture/runtime/generated.ts && node scripts/extract-task-schema-components.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint:ci": "eslint . --format @microsoft/eslint-formatter-sarif -o eslint.sarif",

--- a/scripts/extract-task-schema-components.mjs
+++ b/scripts/extract-task-schema-components.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Extracts the OpenAPI components the task input/output JSON Schemas can
+// $ref, for client-side resolution. Page envelopes are never referenced by
+// task schemas and only bloat the bundle, so they are dropped.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const specPath = new URL("../modules/aperture/openapi.json", import.meta.url);
+const outPath = new URL("../modules/aperture/runtime/taskSchemaComponents.json", import.meta.url);
+
+const spec = JSON.parse(readFileSync(specPath, "utf8"));
+const components = spec.components?.schemas ?? {};
+
+const trimmed = Object.fromEntries(
+  Object.entries(components).filter(([name]) => !name.startsWith("Page_")),
+);
+
+const body = JSON.stringify(trimmed, null, 2) + "\n";
+writeFileSync(outPath, body);
+console.log(
+  `taskSchemaComponents.json: ${Object.keys(trimmed).length} schemas, ${body.length} bytes`,
+);

--- a/scripts/extract-task-schema-components.ts
+++ b/scripts/extract-task-schema-components.ts
@@ -2,13 +2,21 @@
 // Extracts the OpenAPI components the task input/output JSON Schemas can
 // $ref, for client-side resolution. Page envelopes are never referenced by
 // task schemas and only bloat the bundle, so they are dropped.
+//
+// Run with plain `node` (>= 23.6); the syntax is erasable-only TypeScript.
 
 import { readFileSync, writeFileSync } from "node:fs";
+
+interface OpenApiSpec {
+  components?: {
+    schemas?: Record<string, unknown>;
+  };
+}
 
 const specPath = new URL("../modules/aperture/openapi.json", import.meta.url);
 const outPath = new URL("../modules/aperture/runtime/taskSchemaComponents.json", import.meta.url);
 
-const spec = JSON.parse(readFileSync(specPath, "utf8"));
+const spec: OpenApiSpec = JSON.parse(readFileSync(specPath, "utf8"));
 const components = spec.components?.schemas ?? {};
 
 const trimmed = Object.fromEntries(

--- a/test/schemaDisplay.test.ts
+++ b/test/schemaDisplay.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  pickOneOfBranch,
+  resolveRef,
+  schemaEntries,
+  type JsonSchemaLike,
+} from "~/utils/schemaDisplay";
+
+const components: Record<string, JsonSchemaLike> = {
+  ArtifactKey: { type: "string", description: "Logical artifact key." },
+  DownloadSource: {
+    oneOf: [
+      {
+        type: "object",
+        description: "A layer of an OCI image.",
+        required: ["reference", "media_type", "type"],
+        properties: {
+          reference: { type: "string" },
+          media_type: { type: "string" },
+          type: { type: "string", enum: ["oci"] },
+        },
+      },
+    ],
+  },
+  DownloadInput: {
+    type: "object",
+    required: ["key", "source"],
+    properties: {
+      key: { $ref: "#/components/schemas/ArtifactKey", description: "Logical key." },
+      source: { $ref: "#/components/schemas/DownloadSource" },
+    },
+  },
+};
+
+describe("resolveRef", () => {
+  it("resolves a $ref to its component", () => {
+    const resolved = resolveRef({ $ref: "#/components/schemas/ArtifactKey" }, components);
+    expect(resolved?.type).toBe("string");
+    expect(resolved?.description).toBe("Logical artifact key.");
+  });
+
+  it("lets sibling keywords win over the target", () => {
+    const resolved = resolveRef(
+      { $ref: "#/components/schemas/ArtifactKey", description: "override" },
+      components,
+    );
+    expect(resolved?.description).toBe("override");
+    expect(resolved?.type).toBe("string");
+  });
+
+  it("returns the schema untouched without a $ref", () => {
+    const schema: JsonSchemaLike = { type: "string" };
+    expect(resolveRef(schema, components)).toBe(schema);
+  });
+
+  it("returns undefined for unknown refs", () => {
+    expect(resolveRef({ $ref: "#/components/schemas/Nope" }, components)).toBeUndefined();
+  });
+});
+
+describe("pickOneOfBranch", () => {
+  const branches = components.DownloadSource!.oneOf!;
+
+  it("picks the branch matching the discriminator tag", () => {
+    const value = {
+      type: "oci",
+      reference: "ghcr.io/org/img:tag",
+      media_type: "application/vnd.oci.image.layer.v1.tar",
+    };
+    expect(pickOneOfBranch(branches, value)).toBe(branches[0]);
+  });
+
+  it("falls back to required-property scoring without a tag", () => {
+    const noTag: JsonSchemaLike[] = [
+      {
+        type: "object",
+        required: ["a", "b", "c"],
+        properties: { a: { type: "string" }, b: { type: "string" }, c: { type: "string" } },
+      },
+      {
+        type: "object",
+        required: ["a", "b"],
+        properties: { a: { type: "string" }, b: { type: "string" } },
+      },
+    ];
+    expect(pickOneOfBranch(noTag, { a: "1", b: "2" })).toBe(noTag[1]);
+  });
+
+  it("returns undefined for non-object values", () => {
+    expect(pickOneOfBranch(branches, "oci")).toBeUndefined();
+    expect(pickOneOfBranch(branches, null)).toBeUndefined();
+  });
+
+  it("returns undefined when no branch matches", () => {
+    expect(pickOneOfBranch(branches, { unrelated: true })).toBeUndefined();
+  });
+});
+
+describe("schemaEntries", () => {
+  it("orders rows by schema properties and resolves refs", () => {
+    const value = { source: { type: "oci", reference: "r", media_type: "m" }, key: "spectra" };
+    const rows = schemaEntries(components.DownloadInput!, value, components)!;
+    expect(rows.map((r) => r.key)).toEqual(["key", "source"]);
+    expect(rows[0].description).toBe("Logical key.");
+    expect(rows[0].schema?.type).toBe("string");
+  });
+
+  it("appends value keys missing from the schema", () => {
+    const value = {
+      key: "spectra",
+      source: { type: "oci", reference: "r", media_type: "m" },
+      extra: 1,
+    };
+    const rows = schemaEntries(components.DownloadInput!, value, components)!;
+    expect(rows.at(-1)).toMatchObject({ key: "extra", label: "extra", value: 1 });
+    expect(rows.at(-1)?.schema).toBeUndefined();
+  });
+
+  it("skips schema properties the value does not carry", () => {
+    const rows = schemaEntries(components.DownloadInput!, { key: "spectra" }, components)!;
+    expect(rows.map((r) => r.key)).toEqual(["key"]);
+  });
+
+  it("returns undefined for non-object values", () => {
+    expect(schemaEntries(components.DownloadInput!, "nope", components)).toBeUndefined();
+    expect(schemaEntries(components.DownloadInput!, null, components)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Renders task input and output against the kind's JSON Schema instead
of raw JSON: labeled fields with description tooltips, enum badges,
boolean icons, nested objects and arrays, and oneOf branch selection
via the discriminator tag. Each card keeps a raw JSON toggle.

$ref targets resolve against the spec components bundled by a new
post-generate step (Page_ envelopes stripped), which the aperture-sync
workflow keeps in sync. Stacked on #255.