### PR TITLE
feat: schema-driven create task form

### DIFF
--- a/app/components/SchemaForm.vue
+++ b/app/components/SchemaForm.vue
@@ -1,0 +1,279 @@
+<script setup lang="ts">
+/* eslint-disable vue/no-mutating-props -- the state object is owned by the
+   surrounding UForm and shared by reference, like any nested form state. */
+import { resolveRef, type JsonSchemaLike } from "~/utils/schemaDisplay";
+import { buildFormState, oneOfBranchTag, type FormState, type FormValue } from "~/utils/schemaForm";
+
+const props = withDefaults(
+  defineProps<{
+    schema: JsonSchemaLike;
+    state: FormState;
+    namePrefix?: string;
+    depth?: number;
+  }>(),
+  { namePrefix: "", depth: 0 },
+);
+
+const MAX_DEPTH = 6;
+
+function typeOf(schema: JsonSchemaLike | undefined): string | undefined {
+  if (!schema) return undefined;
+  if (typeof schema.type === "string") return schema.type;
+  if (Array.isArray(schema.type)) return schema.type.find((t) => t !== "null");
+  return undefined;
+}
+
+function enumValues(schema: JsonSchemaLike | undefined): string[] | undefined {
+  if (!schema?.enum?.length) return undefined;
+  return schema.enum.filter((v): v is string => typeof v === "string");
+}
+
+interface Field {
+  key: string;
+  label: string;
+  description?: string;
+  schema: JsonSchemaLike | undefined;
+  path: string;
+  kind: "branch-select" | "object" | "array" | "enum" | "boolean" | "number" | "text";
+  branches?: { label: string; branch: JsonSchemaLike }[];
+}
+
+const branchChoices = reactive(new Map<string, string>());
+
+function classify(field: Omit<Field, "kind" | "branches">): Pick<Field, "kind" | "branches"> {
+  const schema = field.schema;
+  if (schema?.oneOf?.length) {
+    const branches = schema.oneOf.map((branch) => ({
+      label: branch.description ?? String(oneOfBranchTag(branch)?.[1] ?? branch.title ?? "option"),
+      branch,
+    }));
+    return { kind: "branch-select", branches };
+  }
+  switch (typeOf(schema)) {
+    case "object":
+      return props.depth < MAX_DEPTH ? { kind: "object" } : { kind: "text" };
+    case "array":
+      return props.depth < MAX_DEPTH ? { kind: "array" } : { kind: "text" };
+    case "boolean":
+      return { kind: "boolean" };
+    case "number":
+    case "integer":
+      return { kind: "number" };
+    default:
+      return enumValues(schema)?.length ? { kind: "enum" } : { kind: "text" };
+  }
+}
+
+const fields = computed<Field[]>(() => {
+  const schema = resolveRef(props.schema);
+  if (!schema?.properties) return [];
+  return Object.entries(schema.properties)
+    .map(([key, prop]) => {
+      const resolved = resolveRef(prop);
+      const base = {
+        key,
+        label: resolved?.title ?? key,
+        description: resolved?.description,
+        schema: resolved,
+        path: props.namePrefix ? `${props.namePrefix}.${key}` : key,
+      };
+      // A single oneOf branch becomes the effective schema; its tag constant
+      // is already injected into the state by buildFormState.
+      const single = resolved?.oneOf?.length === 1 ? resolveRef(resolved.oneOf[0]!) : undefined;
+      const field: Field = {
+        ...base,
+        schema: single ?? base.schema!,
+        ...classify({ ...base, schema: single ?? base.schema }),
+      };
+      return field;
+    })
+    .filter((f) => !isTagField(f));
+});
+
+/**
+ * Single-value enum properties are oneOf discriminator tags. Their value is
+ * injected into the state, so they never render as a field.
+ */
+function isTagField(field: Field): boolean {
+  return field.kind === "enum" && field.schema?.enum?.length === 1;
+}
+
+function selectedBranch(field: Field): JsonSchemaLike | undefined {
+  if (field.kind !== "branch-select" || !field.branches) return undefined;
+  const label = branchChoices.get(field.key) ?? field.branches[0]?.label;
+  return field.branches.find((b) => b.label === label)?.branch;
+}
+
+function selectBranch(field: Field, label: string | undefined) {
+  branchChoices.set(field.key, label ?? "");
+  const branch = field.branches?.find((b) => b.label === label)?.branch;
+  if (!branch) return;
+  const nested = buildFormState(branch);
+  const tag = oneOfBranchTag(branch);
+  if (tag) nested[tag[0]] = tag[1];
+  props.state[field.key] = nested;
+}
+
+function isRecord(value: FormValue | undefined): value is FormState {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stateAt(key: string): FormState | undefined {
+  const v = props.state[key];
+  return isRecord(v) ? v : undefined;
+}
+
+function itemAt(key: string, index: number): FormState | undefined {
+  const v = asArray(key)[index];
+  return isRecord(v) ? v : undefined;
+}
+
+function asArray(key: string): FormValue[] {
+  const v = props.state[key];
+  return Array.isArray(v) ? v : [];
+}
+
+function addItem(field: Field) {
+  const arr = [...asArray(field.key)];
+  arr.push(buildFormState(field.schema?.items ?? {}));
+  props.state[field.key] = arr;
+}
+
+function removeItem(field: Field, index: number) {
+  const arr = [...asArray(field.key)];
+  arr.splice(index, 1);
+  props.state[field.key] = arr;
+}
+
+function setLeaf(key: string, value: FormValue) {
+  props.state[key] = value;
+}
+
+function setArrayItem(key: string, index: number, value: string) {
+  const arr = [...asArray(key)];
+  arr[index] = value;
+  props.state[key] = arr;
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <template v-for="field in fields" :key="field.key">
+      <UFormField
+        v-if="field.kind === 'branch-select'"
+        :label="field.label"
+        :description="field.description"
+        :name="field.path"
+      >
+        <USelectMenu
+          :model-value="branchChoices.get(field.key) || field.branches![0]!.label"
+          :items="field.branches!.map((b) => b.label)"
+          class="w-full"
+          @update:model-value="(v) => selectBranch(field, typeof v === 'string' ? v : undefined)"
+        />
+        <div
+          v-if="selectedBranch(field) && stateAt(field.key)"
+          class="border border-default rounded-md p-3 w-full"
+        >
+          <SchemaForm
+            :schema="selectedBranch(field)!"
+            :state="stateAt(field.key)!"
+            :name-prefix="field.path"
+            :depth="depth + 1"
+          />
+        </div>
+      </UFormField>
+
+      <div v-else-if="field.kind === 'object'" class="flex flex-col gap-1">
+        <span v-if="field.label" class="text-sm font-medium">{{ field.label }}</span>
+        <span v-if="field.description" class="text-xs text-muted-foreground">
+          {{ field.description }}
+        </span>
+        <div class="border border-default rounded-md p-3">
+          <SchemaForm
+            v-if="stateAt(field.key)"
+            :schema="field.schema!"
+            :state="stateAt(field.key)!"
+            :name-prefix="field.path"
+            :depth="depth + 1"
+          />
+        </div>
+      </div>
+
+      <UFormField
+        v-else-if="field.kind === 'array'"
+        :label="field.label"
+        :description="field.description"
+        :name="field.path"
+      >
+        <div class="flex flex-col gap-2 w-full">
+          <div
+            v-for="(_, i) in asArray(field.key)"
+            :key="i"
+            class="flex items-start gap-2 border border-default rounded-md p-2"
+          >
+            <div class="flex-1 min-w-0">
+              <SchemaForm
+                v-if="itemAt(field.key, i)"
+                :schema="field.schema!.items!"
+                :state="itemAt(field.key, i)!"
+                :name-prefix="`${field.path}.${i}`"
+                :depth="depth + 1"
+              />
+              <UInput
+                v-else
+                :model-value="String(asArray(field.key)[i] ?? '')"
+                class="w-full"
+                @update:model-value="(v) => setArrayItem(field.key, i, v)"
+              />
+            </div>
+            <UButton
+              icon="i-lucide-trash"
+              color="error"
+              variant="ghost"
+              size="xs"
+              @click="removeItem(field, i)"
+            />
+          </div>
+          <UButton
+            icon="i-lucide-plus"
+            color="neutral"
+            variant="outline"
+            size="xs"
+            class="self-start"
+            :label="$t('common.add')"
+            @click="addItem(field)"
+          />
+        </div>
+      </UFormField>
+
+      <UFormField v-else :label="field.label" :description="field.description" :name="field.path">
+        <USelectMenu
+          v-if="field.kind === 'enum'"
+          :model-value="String(state[field.key] ?? '')"
+          :items="enumValues(field.schema)!"
+          class="w-full"
+          @update:model-value="(v) => setLeaf(field.key, typeof v === 'string' ? v : '')"
+        />
+        <UCheckbox
+          v-else-if="field.kind === 'boolean'"
+          :model-value="state[field.key] === true"
+          @update:model-value="(v) => setLeaf(field.key, v === true)"
+        />
+        <UInput
+          v-else-if="field.kind === 'number'"
+          :model-value="String(state[field.key] ?? '')"
+          type="number"
+          class="w-full"
+          @update:model-value="(v) => setLeaf(field.key, v)"
+        />
+        <UInput
+          v-else
+          :model-value="String(state[field.key] ?? '')"
+          class="w-full"
+          @update:model-value="(v) => setLeaf(field.key, v)"
+        />
+      </UFormField>
+    </template>
+  </div>
+</template>

--- a/app/components/SchemaForm.vue
+++ b/app/components/SchemaForm.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-/* eslint-disable vue/no-mutating-props -- the state object is owned by the
-   surrounding UForm and shared by reference, like any nested form state. */
 import { resolveRef, type JsonSchemaLike } from "~/utils/schemaDisplay";
 import { buildFormState, oneOfBranchTag, type FormState, type FormValue } from "~/utils/schemaForm";
 
 const props = withDefaults(
   defineProps<{
     schema: JsonSchemaLike;
-    state: FormState;
     namePrefix?: string;
     depth?: number;
   }>(),
   { namePrefix: "", depth: 0 },
 );
+
+// The form state is owned by the surrounding UForm and shared by reference.
+const state = defineModel<FormState>("state", { required: true });
 
 const MAX_DEPTH = 6;
 
@@ -111,7 +111,7 @@ function selectBranch(field: Field, label: string | undefined) {
   const nested = buildFormState(branch);
   const tag = oneOfBranchTag(branch);
   if (tag) nested[tag[0]] = tag[1];
-  props.state[field.key] = nested;
+  state.value[field.key] = nested;
 }
 
 function isRecord(value: FormValue | undefined): value is FormState {
@@ -119,7 +119,7 @@ function isRecord(value: FormValue | undefined): value is FormState {
 }
 
 function stateAt(key: string): FormState | undefined {
-  const v = props.state[key];
+  const v = state.value[key];
   return isRecord(v) ? v : undefined;
 }
 
@@ -129,30 +129,30 @@ function itemAt(key: string, index: number): FormState | undefined {
 }
 
 function asArray(key: string): FormValue[] {
-  const v = props.state[key];
+  const v = state.value[key];
   return Array.isArray(v) ? v : [];
 }
 
 function addItem(field: Field) {
   const arr = [...asArray(field.key)];
   arr.push(buildFormState(field.schema?.items ?? {}));
-  props.state[field.key] = arr;
+  state.value[field.key] = arr;
 }
 
 function removeItem(field: Field, index: number) {
   const arr = [...asArray(field.key)];
   arr.splice(index, 1);
-  props.state[field.key] = arr;
+  state.value[field.key] = arr;
 }
 
 function setLeaf(key: string, value: FormValue) {
-  props.state[key] = value;
+  state.value[key] = value;
 }
 
 function setArrayItem(key: string, index: number, value: string) {
   const arr = [...asArray(key)];
   arr[index] = value;
-  props.state[key] = arr;
+  state.value[key] = arr;
 }
 </script>
 

--- a/app/pages/operations/tasks/index.vue
+++ b/app/pages/operations/tasks/index.vue
@@ -294,8 +294,8 @@ async function onCreate() {
           </p>
           <SchemaForm
             v-else-if="createInputSchema"
+            v-model:state="createState"
             :schema="createInputSchema"
-            :state="createState"
           />
 
           <div class="flex justify-end gap-2">

--- a/app/pages/operations/tasks/index.vue
+++ b/app/pages/operations/tasks/index.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
 import type { SelectMenuItem } from "@nuxt/ui";
+import * as z from "zod/v4/mini";
 import { useIntervalFn } from "@vueuse/core";
-import type { ListTasksParams, Task, TaskDefinition } from "~~/modules/aperture/runtime/types";
+import type {
+  CreateTaskBody,
+  ListTasksParams,
+  Task,
+  TaskDefinition,
+} from "~~/modules/aperture/runtime/types";
+import type { JsonSchemaLike } from "~/utils/schemaDisplay";
+import { buildFormState, buildZodSchema, cleanFormState, type FormState } from "~/utils/schemaForm";
 import {
   TASK_STATUS_FILTERS,
   tasksParamsFromFilters,
@@ -10,6 +18,7 @@ import {
 import { TASK_STATUS_COLORS, useTaskDisplay } from "~/composables/useTaskDisplay";
 
 const { t } = useI18n();
+const toast = useToast();
 const localePath = useLocalePath();
 const { formatTimestamp, formatDuration, progressPercent, progressMessage } = useTaskDisplay();
 
@@ -59,6 +68,71 @@ const { pause, resume } = useIntervalFn(() => void reload(), 3000);
 watch(hasActiveTasks, (active) => (active ? resume() : pause()), { immediate: true });
 
 onUnmounted(pause);
+
+// Create task: the input form is generated from the kind's JSON Schema.
+
+const createOpen = ref(false);
+const createKind = ref<string | undefined>(undefined);
+const createState = ref<FormState>({});
+const creating = ref(false);
+
+const createKindItems = computed<SelectMenuItem[]>(() =>
+  (definitions.value ?? []).map((d) => ({ label: d.kind, value: d.kind })),
+);
+
+const selectedDefinition = computed<TaskDefinition | undefined>(() =>
+  (definitions.value ?? []).find((d) => d.kind === createKind.value),
+);
+
+const createInputSchema = computed<JsonSchemaLike | undefined>(() => {
+  const schema = selectedDefinition.value?.input_schema;
+  return typeof schema === "object" && schema !== null ? (schema as JsonSchemaLike) : undefined;
+});
+
+const createZodSchema = computed(() =>
+  createInputSchema.value ? buildZodSchema(createInputSchema.value) : z.object({}),
+);
+
+watch(createKind, (kind) => {
+  const def = (definitions.value ?? []).find((d) => d.kind === kind);
+  const schema =
+    typeof def?.input_schema === "object" && def?.input_schema !== null
+      ? (def.input_schema as JsonSchemaLike)
+      : undefined;
+  createState.value = schema ? buildFormState(schema) : {};
+});
+
+function openCreate() {
+  createKind.value = definitions.value?.[0]?.kind;
+  createOpen.value = true;
+}
+
+async function onCreate() {
+  if (!createKind.value) return;
+  creating.value = true;
+  try {
+    const payload = {
+      kind: createKind.value,
+      input: cleanFormState(createState.value, createInputSchema.value),
+    };
+    // The generated client narrows the body to the known kinds' unions; the
+    // schema-driven payload is valid at runtime for any kind.
+    await apertureApi.createTask(payload as CreateTaskBody);
+    createOpen.value = false;
+    toast.add({ title: t("operations.tasks.created"), color: "success" });
+    await reload();
+  } catch (err) {
+    toast.add({
+      title:
+        err instanceof ApiError && err.status === 400
+          ? t("operations.tasks.createInvalid")
+          : t("operations.tasks.createFailed"),
+      color: "error",
+    });
+  } finally {
+    creating.value = false;
+  }
+}
 </script>
 
 <template>
@@ -68,7 +142,7 @@ onUnmounted(pause);
         <USelectMenu
           v-model="filters.status"
           :items="statusItems"
-          value-attribute="value"
+          value-key="value"
           size="sm"
           class="w-44"
         />
@@ -76,7 +150,7 @@ onUnmounted(pause);
         <USelectMenu
           v-model="filters.kind"
           :items="kindItems"
-          value-attribute="value"
+          value-key="value"
           size="sm"
           class="w-44"
         />
@@ -86,6 +160,14 @@ onUnmounted(pause);
           :label="$t('operations.tasks.filters.rootOnly')"
           size="sm"
           @update:model-value="(v) => (filters.root = v === true)"
+        />
+
+        <UButton
+          icon="i-lucide-plus"
+          size="sm"
+          :label="$t('operations.tasks.create')"
+          :disabled="!definitions?.length"
+          @click="openCreate()"
         />
 
         <UButton
@@ -186,5 +268,42 @@ onUnmounted(pause);
         />
       </DataState>
     </div>
+
+    <UModal v-model:open="createOpen" :title="$t('operations.tasks.create')">
+      <template #body>
+        <UForm
+          :schema="createZodSchema"
+          :state="createState"
+          class="flex flex-col gap-4"
+          @submit="onCreate"
+        >
+          <UFormField :label="$t('operations.tasks.filters.kind')" name="kind">
+            <USelectMenu
+              v-model="createKind"
+              :items="createKindItems"
+              value-key="value"
+              class="w-full"
+            />
+          </UFormField>
+
+          <p
+            v-if="createInputSchema && !Object.keys(createInputSchema.properties ?? {}).length"
+            class="text-muted text-sm"
+          >
+            {{ $t("common.noParameters") }}
+          </p>
+          <SchemaForm
+            v-else-if="createInputSchema"
+            :schema="createInputSchema"
+            :state="createState"
+          />
+
+          <div class="flex justify-end gap-2">
+            <UButton variant="ghost" :label="$t('common.cancel')" @click="createOpen = false" />
+            <UButton type="submit" :loading="creating" :label="$t('common.create')" />
+          </div>
+        </UForm>
+      </template>
+    </UModal>
   </AppPage>
 </template>

--- a/app/pages/settings/api-keys.vue
+++ b/app/pages/settings/api-keys.vue
@@ -131,7 +131,7 @@ function formatLastUsed(value: ApiKey["last_used_at"]): string {
             <USelectMenu
               v-model="createState.role"
               :items="roleItems"
-              value-attribute="value"
+              value-key="value"
               class="w-full"
             />
           </UFormField>

--- a/app/pages/settings/users.vue
+++ b/app/pages/settings/users.vue
@@ -138,7 +138,7 @@ async function onDelete(target: User) {
             <USelectMenu
               v-model="createState.role"
               :items="roleItems"
-              value-attribute="value"
+              value-key="value"
               class="w-full"
             />
           </UFormField>

--- a/app/utils/schemaForm.ts
+++ b/app/utils/schemaForm.ts
@@ -1,0 +1,190 @@
+import * as z from "zod/v4/mini";
+import { resolveRef, type JsonSchemaLike } from "~/utils/schemaDisplay";
+
+export type FormValue =
+  string | number | boolean | null | FormValue[] | { [key: string]: FormValue };
+export type FormState = { [key: string]: FormValue };
+
+function typeOf(schema: JsonSchemaLike): string | undefined {
+  if (typeof schema.type === "string") return schema.type;
+  if (Array.isArray(schema.type)) return schema.type.find((t) => t !== "null");
+  return undefined;
+}
+
+/**
+ * The branch a `oneOf` schema should use for form state. A single tagged
+ * branch (`type`/`kind` enum with one value) is auto-selected; with several
+ * candidates the caller must let the user choose.
+ */
+export function defaultOneOfBranch(
+  schema: JsonSchemaLike,
+): { branch: JsonSchemaLike; tag?: [string, FormValue] } | undefined {
+  if (!schema.oneOf?.length) return undefined;
+  const tagged = schema.oneOf.filter((b) => oneOfBranchTag(b) !== undefined);
+  if (tagged.length === 1) {
+    const branch = tagged[0]!;
+    const tag = oneOfBranchTag(branch);
+    return tag ? { branch, tag } : { branch };
+  }
+  if (schema.oneOf.length === 1) return { branch: schema.oneOf[0]! };
+  return undefined;
+}
+
+export function oneOfBranchTag(branch: JsonSchemaLike): [string, FormValue] | undefined {
+  for (const key of ["type", "kind"]) {
+    const value = branch.properties?.[key]?.enum?.[0];
+    if (value !== undefined) return [key, value as FormValue];
+  }
+  return undefined;
+}
+
+/**
+ * Seeds form state from a schema: `default` values when present, empty
+ * strings/objects/arrays otherwise. OneOf branches with a single tagged
+ * variant are auto-selected and the tag constant is injected.
+ */
+export function buildFormState(schemaIn: JsonSchemaLike): FormState {
+  const state: FormState = {};
+  let schema = resolveRef(schemaIn);
+  if (schema?.oneOf?.length) {
+    const branch = defaultOneOfBranch(schema);
+    if (branch) {
+      schema = branch.branch;
+      if (branch.tag) {
+        const nested = buildFormState(branch.branch);
+        nested[branch.tag[0]] = branch.tag[1];
+        return nested;
+      }
+    } else {
+      return {};
+    }
+  }
+  if (!schema?.properties) return state;
+
+  for (const [key, propIn] of Object.entries(schema.properties)) {
+    const prop = resolveRef(propIn);
+    if (!prop) continue;
+
+    if (prop.default !== undefined) {
+      state[key] = prop.default as FormValue;
+      continue;
+    }
+
+    const branch = defaultOneOfBranch(prop);
+    if (branch) {
+      const nested = buildFormState(branch.branch);
+      if (branch.tag) nested[branch.tag[0]] = branch.tag[1];
+      state[key] = nested;
+      continue;
+    }
+
+    switch (typeOf(prop)) {
+      case "object":
+        state[key] = buildFormState(prop);
+        break;
+      case "array":
+        state[key] = [];
+        break;
+      case "boolean":
+        state[key] = false;
+        break;
+      default:
+        state[key] = "";
+        break;
+    }
+  }
+  return state;
+}
+
+function isFormState(value: FormValue): value is FormState {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Strips empty-string and empty-array placeholders and converts numeric
+ * fields (kept as strings for the inputs) to numbers, so the request body
+ * only carries values the user actually entered.
+ */
+export function cleanFormState(state: FormState, schemaIn?: JsonSchemaLike): FormState {
+  const schema = schemaIn ? resolveRef(schemaIn) : undefined;
+  const out: FormState = {};
+  for (const [key, value] of Object.entries(state)) {
+    if (value === "") continue;
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue;
+      const items = schema?.properties?.[key]?.items;
+      out[key] = value.map((v) => (isFormState(v) ? cleanFormState(v, items) : v));
+      continue;
+    }
+    if (isFormState(value)) {
+      out[key] = cleanFormState(value, schema?.properties?.[key]);
+      continue;
+    }
+    if (
+      typeof value === "string" &&
+      (typeOf(schema?.properties?.[key] ?? {}) === "number" ||
+        typeOf(schema?.properties?.[key] ?? {}) === "integer") &&
+      value.trim() !== "" &&
+      !Number.isNaN(Number(value))
+    ) {
+      out[key] = Number(value);
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+const NUMBER_RE = /^-?\d+(\.\d+)?$/;
+const INTEGER_RE = /^-?\d+$/;
+
+/**
+ * Builds a zod schema validating form state against the JSON Schema:
+ * required checks, enum domains, numeric strings, nested objects, and
+ * arrays. Optional fields accept the empty-string placeholder.
+ */
+export function buildZodSchema(schemaIn: JsonSchemaLike, required = true): z.core.$ZodType {
+  const schema = resolveRef(schemaIn) ?? schemaIn;
+
+  if (schema.oneOf?.length) {
+    const branch = defaultOneOfBranch(schema)?.branch;
+    if (branch) return buildZodSchema(branch, required);
+  }
+
+  switch (typeOf(schema)) {
+    case "object": {
+      const shape: Record<string, z.core.$ZodType> = {};
+      const req = new Set(schema.required ?? []);
+      for (const [key, propIn] of Object.entries(schema.properties ?? {})) {
+        const prop = resolveRef(propIn);
+        if (!prop) continue;
+        const field = buildZodSchema(prop, req.has(key));
+        // Optional fields accept absence and the empty-string placeholder.
+        shape[key] = req.has(key) ? field : z.optional(z.union([z.literal(""), field]));
+      }
+      return z.object(shape);
+    }
+    case "array": {
+      const items = schema.items ? buildZodSchema(schema.items, true) : z.any();
+      const arr = z.array(items);
+      return required ? arr.check(z.minLength(1)) : arr;
+    }
+    case "boolean":
+      return z.boolean();
+    case "number":
+    case "integer": {
+      const re = typeOf(schema) === "integer" ? INTEGER_RE : NUMBER_RE;
+      const num = z.string().check(z.regex(re));
+      return required ? num.check(z.minLength(1)) : num;
+    }
+    case "string": {
+      if (schema.enum?.length && schema.enum.every((v): v is string => typeof v === "string")) {
+        const values: [string, ...string[]] = schema.enum as [string, ...string[]];
+        return z.enum(values);
+      }
+      return required ? z.string().check(z.minLength(1)) : z.string();
+    }
+    default:
+      return z.any();
+  }
+}

--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -238,3 +238,122 @@ test("task detail renders and cancels", async ({ page }) => {
   await page.getByRole("button", { name: "Cancel task" }).click();
   await expect(page.getByText("Cancelled")).toBeVisible({ timeout: 10_000 });
 });
+
+const createDefinitions = [
+  {
+    kind: "rotate-certificate",
+    cancellable: false,
+    resumable: true,
+    input_schema: { type: "object" },
+    output_schema: { type: "object" },
+  },
+  {
+    kind: "download",
+    cancellable: true,
+    resumable: false,
+    input_schema: downloadDefinition.input_schema,
+    output_schema: { type: "object" },
+  },
+];
+
+test("create task form is driven by the kind schema", async ({ page }) => {
+  const created: unknown[] = [];
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const pathname = url.pathname;
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/tasks" && request.method() === "POST") {
+      created.push(request.postDataJSON());
+      await route.fulfill({ status: 202, contentType: "application/json", body: "{}" });
+      return;
+    }
+
+    if (pathname === "/api/v1/tasks") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/task-definitions") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(createDefinitions),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.goto("/en/operations/tasks", { waitUntil: "domcontentloaded" });
+  await page.getByRole("button", { name: "New task" }).click();
+
+  // Default kind (first definition) takes no parameters.
+  await expect(page.getByText("No parameters.")).toBeVisible();
+
+  // Switch to the download kind: schema fields appear.
+  await page.getByRole("button", { name: "Show popup" }).click();
+  await page.getByRole("option", { name: "download" }).click();
+
+  // The schema-driven inputs replace their DOM nodes once, right after the
+  // kind switch; a fill landing on the stale node is lost. Verify and retry.
+  const typeStable = async (name: string, value: string) => {
+    const box = page.getByRole("textbox", { name });
+    await box.click();
+    await page.keyboard.type(value, { delay: 20 });
+    await expect(box).toHaveValue(value);
+  };
+
+  await typeStable("key", "firmware");
+  await typeStable("reference", "ghcr.io/stargrid-systems/firmware:1.2.3");
+  await typeStable("media_type", "application/vnd.oci.image.layer.v1.tar");
+
+  await page.getByRole("button", { name: "Create" }).click();
+
+  await expect.poll(() => created.length).toBe(1);
+  expect(created[0]).toEqual({
+    kind: "download",
+    input: {
+      key: "firmware",
+      source: {
+        type: "oci",
+        reference: "ghcr.io/stargrid-systems/firmware:1.2.3",
+        media_type: "application/vnd.oci.image.layer.v1.tar",
+      },
+    },
+  });
+});

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -8,6 +8,7 @@
   "go-to": "Gehe zu",
   "notifications": "Benachrichtigungen",
   "common": {
+    "add": "Hinzufügen",
     "cancel": "Abbrechen",
     "create": "Erstellen",
     "done": "Fertig",
@@ -229,6 +230,7 @@
       "notStarted": "Nicht gestartet",
       "filters": {
         "statusAll": "Alle Status",
+        "kind": "Art",
         "kindAll": "Alle Arten",
         "rootOnly": "Nur oberste Ebene"
       },
@@ -247,6 +249,10 @@
       "cancelNotCancellable": "Diese Art von Aufgabe kann nicht abgebrochen werden.",
       "cancelAlreadyFinished": "Diese Aufgabe ist bereits beendet.",
       "cancelFailed": "Aufgabe konnte nicht abgebrochen werden.",
+      "create": "Neue Aufgabe",
+      "created": "Aufgabe erstellt.",
+      "createInvalid": "Die Eingabe ist für diese Art von Aufgabe nicht gültig.",
+      "createFailed": "Aufgabe konnte nicht erstellt werden.",
       "detail": {
         "createdAt": "Erstellt",
         "startedAt": "Gestartet",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -8,6 +8,7 @@
   "go-to": "Go to",
   "notifications": "Notifications",
   "common": {
+    "add": "Add",
     "cancel": "Cancel",
     "create": "Create",
     "done": "Done",
@@ -229,6 +230,7 @@
       "notStarted": "Not started",
       "filters": {
         "statusAll": "All statuses",
+        "kind": "Kind",
         "kindAll": "All kinds",
         "rootOnly": "Top-level only"
       },
@@ -247,6 +249,10 @@
       "cancelNotCancellable": "This task kind cannot be cancelled.",
       "cancelAlreadyFinished": "This task has already finished.",
       "cancelFailed": "Failed to cancel the task.",
+      "create": "New task",
+      "created": "Task created.",
+      "createInvalid": "The input is not valid for this task kind.",
+      "createFailed": "Failed to create the task.",
       "detail": {
         "createdAt": "Created",
         "startedAt": "Started",

--- a/test/schemaForm.test.ts
+++ b/test/schemaForm.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import * as z from "zod/v4/mini";
+import type { JsonSchemaLike } from "~/utils/schemaDisplay";
+import {
+  buildFormState,
+  buildZodSchema,
+  cleanFormState,
+  defaultOneOfBranch,
+  oneOfBranchTag,
+} from "~/utils/schemaForm";
+
+const downloadInput: JsonSchemaLike = {
+  type: "object",
+  required: ["key", "source"],
+  properties: {
+    key: { $ref: "#/components/schemas/ArtifactKey", description: "Logical key." },
+    source: {
+      oneOf: [
+        {
+          type: "object",
+          required: ["reference", "media_type", "type"],
+          properties: {
+            reference: { type: "string" },
+            media_type: { type: "string" },
+            type: { type: "string", enum: ["oci"] },
+          },
+        },
+      ],
+    },
+    retries: { type: "integer", minimum: 0 },
+    verbose: { type: "boolean" },
+  },
+};
+
+describe("defaultOneOfBranch", () => {
+  it("auto-selects a single tagged branch and reports its tag", () => {
+    const schema = downloadInput.properties!.source as JsonSchemaLike;
+    const result = defaultOneOfBranch(schema)!;
+    expect(result.branch).toBe(schema.oneOf![0]);
+    expect(result.tag).toEqual(["type", "oci"]);
+  });
+
+  it("returns undefined for multiple untagged branches", () => {
+    const schema: JsonSchemaLike = {
+      oneOf: [{ type: "object" }, { type: "object" }],
+    };
+    expect(defaultOneOfBranch(schema)).toBeUndefined();
+  });
+});
+
+describe("oneOfBranchTag", () => {
+  it("reads the tag from a kind enum", () => {
+    expect(
+      oneOfBranchTag({ type: "object", properties: { kind: { type: "string", enum: ["x"] } } }),
+    ).toEqual(["kind", "x"]);
+  });
+});
+
+describe("buildFormState", () => {
+  it("seeds defaults, injects the oneOf tag, and empties the rest", () => {
+    const state = buildFormState(downloadInput);
+    expect(state).toEqual({
+      key: "",
+      source: { reference: "", media_type: "", type: "oci" },
+      retries: "",
+      verbose: false,
+    });
+  });
+
+  it("uses schema defaults when present", () => {
+    const state = buildFormState({
+      type: "object",
+      properties: { retries: { type: "integer", default: 3 } },
+    });
+    expect(state.retries).toBe(3);
+  });
+
+  it("returns an empty state without properties", () => {
+    expect(buildFormState({ type: "object" })).toEqual({});
+  });
+});
+
+describe("cleanFormState", () => {
+  it("strips placeholders, keeps entered values, and converts numbers", () => {
+    const state = {
+      key: "spectra",
+      source: { reference: "ghcr.io/org/img:1", media_type: "", type: "oci" },
+      retries: "2",
+      verbose: false,
+    };
+    expect(cleanFormState(state, downloadInput)).toEqual({
+      key: "spectra",
+      source: { reference: "ghcr.io/org/img:1", type: "oci" },
+      retries: 2,
+      verbose: false,
+    });
+  });
+
+  it("keeps booleans as booleans", () => {
+    expect(cleanFormState({ verbose: true }, downloadInput)).toEqual({ verbose: true });
+  });
+});
+
+describe("buildZodSchema", () => {
+  const schema = buildZodSchema(downloadInput);
+
+  it("accepts a filled state", () => {
+    const state = {
+      key: "spectra",
+      source: { reference: "r", media_type: "m", type: "oci" },
+      retries: "1",
+      verbose: false,
+    };
+    expect(z.parse(schema, state)).toEqual(state);
+  });
+
+  it("rejects a missing required field", () => {
+    const state = {
+      key: "",
+      source: { reference: "r", media_type: "m", type: "oci" },
+    };
+    const result = z.safeParse(schema, state);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-numeric numbers and non-integer integers", () => {
+    const badNum = {
+      key: "k",
+      source: { reference: "r", media_type: "m", type: "oci" },
+      retries: "abc",
+    };
+    expect(z.safeParse(schema, badNum).success).toBe(false);
+    const float = {
+      key: "k",
+      source: { reference: "r", media_type: "m", type: "oci" },
+      retries: "1.5",
+    };
+    expect(z.safeParse(schema, float).success).toBe(false);
+  });
+
+  it("allows optional placeholders and wrong enum values are rejected", () => {
+    const okState = { key: "k", source: { reference: "r", media_type: "m", type: "oci" } };
+    expect(z.safeParse(schema, okState).success).toBe(true);
+
+    const badTag = { key: "k", source: { reference: "r", media_type: "m", type: "docker" } };
+    expect(z.safeParse(schema, badTag).success).toBe(false);
+  });
+});


### PR DESCRIPTION
The create-task modal renders its input form from the kind's JSON
Schema: typed widgets per property, nested object sections, oneOf
branch selection with discriminator constants injected, and add/remove
array rows. Validation uses a zod schema built from the same source.

Also fixes a real bug the e2e run surfaced: USelectMenu still used the
v3 prop value-attribute, which v4 ignores, so the task filters and the
role selects in users and api keys bound whole item objects. Stacked
on #256.