### PR TITLE
feat: schedules page

### DIFF
--- a/app/components/IntervalInput.vue
+++ b/app/components/IntervalInput.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import type { SelectMenuItem } from "@nuxt/ui";
+import {
+  durationToUnitCombo,
+  INTERVAL_UNITS,
+  unitComboToDuration,
+  type IntervalUnit,
+} from "~/utils/scheduleInterval";
+
+/**
+ * Interval picker: a whole number plus a unit. Exposes the selection as a
+ * Temporal.Duration; undefined while the number is empty or invalid.
+ */
+const model = defineModel<Temporal.Duration | undefined>("modelValue");
+
+const { t } = useI18n();
+
+// UInput with type "number" emits numbers, not strings.
+const valueText = ref<number | string>("");
+const unit = ref<IntervalUnit>("minute");
+
+const unitItems = computed<SelectMenuItem[]>(() =>
+  INTERVAL_UNITS.map((u) => ({ label: t(`common.durationUnits.${u}`), value: u })),
+);
+
+watch(
+  model,
+  (duration) => {
+    if (!duration) {
+      valueText.value = "";
+      return;
+    }
+    const combo = durationToUnitCombo(duration);
+    if (combo) {
+      valueText.value = combo.value;
+      unit.value = combo.unit;
+    } else {
+      valueText.value = "";
+    }
+  },
+  { immediate: true },
+);
+
+watch([valueText, unit], () => {
+  const n = typeof valueText.value === "number" ? valueText.value : Number(valueText.value);
+  if (valueText.value === "" || valueText.value == null || !Number.isInteger(n) || n < 1) {
+    model.value = undefined;
+    return;
+  }
+  const duration = unitComboToDuration({ value: n, unit: unit.value });
+  if (model.value?.toString() !== duration.toString()) {
+    model.value = duration;
+  }
+});
+</script>
+
+<template>
+  <div class="flex gap-2 w-full">
+    <!-- UInput types modelValue as string but emits numbers for type number. -->
+    <UInput
+      :model-value="valueText === '' ? '' : String(valueText)"
+      type="number"
+      min="1"
+      step="1"
+      class="flex-1"
+      @update:model-value="(v) => (valueText = v ?? '')"
+    />
+    <USelectMenu v-model="unit" :items="unitItems" value-key="value" class="w-32" />
+  </div>
+</template>

--- a/app/components/SchemaForm.vue
+++ b/app/components/SchemaForm.vue
@@ -265,7 +265,7 @@ function setArrayItem(key: string, index: number, value: string) {
           :model-value="String(state[field.key] ?? '')"
           type="number"
           class="w-full"
-          @update:model-value="(v) => setLeaf(field.key, v)"
+          @update:model-value="(v) => setLeaf(field.key, typeof v === 'number' ? String(v) : v)"
         />
         <UInput
           v-else

--- a/app/pages/operations/schedules.vue
+++ b/app/pages/operations/schedules.vue
@@ -1,5 +1,339 @@
+<script setup lang="ts">
+import type { SelectMenuItem } from "@nuxt/ui";
+import * as z from "zod/v4/mini";
+import type {
+  ListTaskSchedulesParams,
+  TaskDefinition,
+  TaskSchedule,
+} from "~~/modules/aperture/runtime/types";
+import type { JsonSchemaLike } from "~/utils/schemaDisplay";
+import { buildFormState, buildZodSchema, cleanFormState, type FormState } from "~/utils/schemaForm";
+
+const { t } = useI18n();
+const toast = useToast();
+const fmt = useFormatter();
+const localePath = useLocalePath();
+
+const { data: definitions } = useAsyncData<TaskDefinition[]>(
+  "task-definitions",
+  () => apertureApi.listTaskDefinitions(),
+  { server: false },
+);
+
+function inputSchemaFor(kind: string): JsonSchemaLike | undefined {
+  const schema = (definitions.value ?? []).find((d) => d.kind === kind)?.input_schema;
+  return typeof schema === "object" && schema !== null ? (schema as JsonSchemaLike) : undefined;
+}
+
+const {
+  items: schedules,
+  pending,
+  error,
+  hasNext,
+  hasPrev,
+  loadNext,
+  loadPrev,
+  reload,
+} = useCursorPager<TaskSchedule, ListTaskSchedulesParams>((query) =>
+  apertureApi.listTaskSchedules(query),
+);
+
+function formatTimestamp(ts: Temporal.Instant): string {
+  return fmt.date(ts, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatInterval(schedule: TaskSchedule): string {
+  return fmt.duration(Temporal.Duration.from(schedule.interval), { fractionDigits: 1 });
+}
+
+async function toggleEnabled(schedule: TaskSchedule) {
+  const next = !schedule.enabled;
+  schedule.enabled = next;
+  try {
+    await apertureApi.updateTaskSchedule(schedule.id, { enabled: next });
+  } catch {
+    schedule.enabled = !next;
+    toast.add({ title: t("operations.schedules.updateFailed"), color: "error" });
+  }
+}
+
+async function onDelete(schedule: TaskSchedule) {
+  try {
+    await apertureApi.deleteTaskSchedule(schedule.id);
+    await reload();
+    toast.add({ title: t("operations.schedules.deleted"), color: "success" });
+  } catch {
+    toast.add({ title: t("operations.schedules.deleteFailed"), color: "error" });
+  }
+}
+
+// Create modal.
+
+const createOpen = ref(false);
+const createKind = ref<string | undefined>(undefined);
+const createState = ref<FormState>({});
+const createInterval = ref<Temporal.Duration | undefined>(undefined);
+const creating = ref(false);
+
+const kindItems = computed<SelectMenuItem[]>(() =>
+  (definitions.value ?? []).map((d) => ({ label: d.kind, value: d.kind })),
+);
+
+const createInputSchema = computed<JsonSchemaLike | undefined>(() =>
+  createKind.value ? inputSchemaFor(createKind.value) : undefined,
+);
+
+const createZodSchema = computed(() =>
+  createInputSchema.value ? buildZodSchema(createInputSchema.value) : z.object({}),
+);
+
+watch(createKind, (kind) => {
+  const schema = kind ? inputSchemaFor(kind) : undefined;
+  createState.value = schema ? buildFormState(schema) : {};
+});
+
+function openCreate() {
+  createKind.value = definitions.value?.[0]?.kind;
+  createInterval.value = undefined;
+  createOpen.value = true;
+}
+
+async function onCreate() {
+  if (!createKind.value || !createInterval.value) return;
+  creating.value = true;
+  try {
+    await apertureApi.createTaskSchedule({
+      kind: createKind.value,
+      input: cleanFormState(createState.value, createInputSchema.value),
+      interval: createInterval.value.toString(),
+    });
+    createOpen.value = false;
+    toast.add({ title: t("operations.schedules.created"), color: "success" });
+    await reload();
+  } catch {
+    toast.add({ title: t("operations.schedules.createFailed"), color: "error" });
+  } finally {
+    creating.value = false;
+  }
+}
+
+// Edit modal.
+
+const editOpen = ref(false);
+const editTarget = ref<TaskSchedule | null>(null);
+const editInterval = ref<Temporal.Duration | undefined>(undefined);
+const editing = ref(false);
+
+function openEdit(schedule: TaskSchedule) {
+  editTarget.value = schedule;
+  editInterval.value = Temporal.Duration.from(schedule.interval);
+  editOpen.value = true;
+}
+
+async function onEdit() {
+  if (!editTarget.value || !editInterval.value) return;
+  editing.value = true;
+  try {
+    await apertureApi.updateTaskSchedule(editTarget.value.id, {
+      interval: editInterval.value.toString(),
+    });
+    editOpen.value = false;
+    toast.add({ title: t("operations.schedules.edited"), color: "success" });
+    await reload();
+  } catch {
+    toast.add({ title: t("operations.schedules.updateFailed"), color: "error" });
+  } finally {
+    editing.value = false;
+  }
+}
+</script>
+
 <template>
   <AppPage :title="$t('operations.schedules.title')">
-    <div class="p-6 text-muted">{{ $t("common.notImplemented") }}</div>
+    <template #toolbar>
+      <div class="flex flex-wrap items-center justify-end gap-2 px-4 py-2 border-b border-default">
+        <UButton
+          variant="ghost"
+          color="neutral"
+          icon="i-lucide-refresh-cw"
+          size="sm"
+          :label="$t('operations.schedules.refresh')"
+          :loading="pending && schedules.length === 0"
+          @click="reload()"
+        />
+        <UButton
+          icon="i-lucide-plus"
+          size="sm"
+          :label="$t('operations.schedules.create')"
+          :disabled="!definitions?.length"
+          @click="openCreate()"
+        />
+      </div>
+    </template>
+
+    <div class="p-4">
+      <DataState
+        :pending="pending && schedules.length === 0"
+        :error="error ? String(error) : null"
+        :empty="schedules.length === 0"
+        :empty-text="$t('operations.schedules.empty')"
+        :error-text="$t('operations.schedules.error')"
+        :retry-text="$t('common.retry')"
+        @retry="reload()"
+      >
+        <div class="flex flex-col gap-2">
+          <UPageCard v-for="schedule in schedules" :key="schedule.id" variant="subtle">
+            <div class="flex flex-col gap-3">
+              <div class="flex flex-wrap sm:items-center justify-between gap-3">
+                <div class="flex items-center gap-3 min-w-0">
+                  <USwitch
+                    :model-value="schedule.enabled"
+                    @update:model-value="() => toggleEnabled(schedule)"
+                  />
+                  <span class="font-mono text-sm truncate">{{ schedule.kind }}</span>
+                  <UBadge :label="formatInterval(schedule)" variant="subtle" />
+                  <span class="text-muted text-xs font-mono hidden md:inline">
+                    {{ schedule.id }}
+                  </span>
+                </div>
+                <div class="flex items-center gap-3 text-xs text-muted">
+                  <span>
+                    {{ $t("operations.schedules.nextRun") }}:
+                    {{ formatTimestamp(schedule.next_run_at) }}
+                  </span>
+                  <span v-if="schedule.last_run_at || schedule.last_task_id">
+                    {{ $t("operations.schedules.lastRun") }}:
+                    <UButton
+                      v-if="schedule.last_task_id"
+                      :to="localePath(`/operations/tasks/${schedule.last_task_id}`)"
+                      variant="link"
+                      size="xs"
+                      class="px-0"
+                      :label="schedule.last_run_at ? formatTimestamp(schedule.last_run_at) : 'task'"
+                    />
+                    <template v-else-if="schedule.last_run_at">
+                      {{ formatTimestamp(schedule.last_run_at) }}
+                    </template>
+                  </span>
+                  <span v-else>
+                    {{ $t("operations.schedules.lastRun") }}: {{ $t("operations.schedules.never") }}
+                  </span>
+                  <UButton
+                    icon="i-lucide-pencil"
+                    color="neutral"
+                    variant="ghost"
+                    size="xs"
+                    :label="$t('operations.schedules.edit')"
+                    @click="openEdit(schedule)"
+                  />
+                  <UButton
+                    icon="i-lucide-trash"
+                    color="error"
+                    variant="ghost"
+                    size="xs"
+                    @click="onDelete(schedule)"
+                  />
+                </div>
+              </div>
+
+              <USeparator />
+
+              <div>
+                <div class="text-xs font-semibold text-muted-foreground mb-1">
+                  {{ $t("operations.schedules.input") }}
+                </div>
+                <SchemaValue
+                  :value="schedule.input"
+                  :schema="inputSchemaFor(schedule.kind)"
+                  :empty-text="$t('common.noParameters')"
+                />
+              </div>
+            </div>
+          </UPageCard>
+        </div>
+
+        <PagerBar
+          :has-prev="hasPrev"
+          :has-next="hasNext"
+          :pending="pending && schedules.length === 0"
+          :prev-text="$t('common.prev')"
+          :next-text="$t('common.next')"
+          @prev="loadPrev()"
+          @next="loadNext()"
+        />
+      </DataState>
+    </div>
+
+    <UModal v-model:open="createOpen" :title="$t('operations.schedules.create')">
+      <template #body>
+        <UForm
+          :schema="createZodSchema"
+          :state="createState"
+          class="flex flex-col gap-4"
+          @submit="onCreate()"
+        >
+          <UFormField :label="$t('operations.tasks.filters.kind')" name="kind">
+            <USelectMenu v-model="createKind" :items="kindItems" value-key="value" class="w-full" />
+          </UFormField>
+
+          <p
+            v-if="createInputSchema && !Object.keys(createInputSchema.properties ?? {}).length"
+            class="text-muted text-sm"
+          >
+            {{ $t("common.noParameters") }}
+          </p>
+          <SchemaForm
+            v-else-if="createInputSchema"
+            v-model:state="createState"
+            :schema="createInputSchema"
+          />
+
+          <UFormField
+            :label="$t('operations.schedules.interval')"
+            name="interval"
+            :help="!createInterval ? $t('operations.schedules.invalidInterval') : undefined"
+          >
+            <IntervalInput v-model="createInterval" />
+          </UFormField>
+
+          <div class="flex justify-end gap-2">
+            <UButton variant="ghost" :label="$t('common.cancel')" @click="createOpen = false" />
+            <UButton
+              type="submit"
+              :loading="creating"
+              :label="$t('common.create')"
+              :disabled="!createInterval"
+            />
+          </div>
+        </UForm>
+      </template>
+    </UModal>
+
+    <UModal v-model:open="editOpen" :title="$t('operations.schedules.edit')">
+      <template #body>
+        <div class="flex flex-col gap-4">
+          <UFormField
+            :label="$t('operations.schedules.interval')"
+            :help="!editInterval ? $t('operations.schedules.invalidInterval') : undefined"
+          >
+            <IntervalInput v-model="editInterval" />
+          </UFormField>
+          <div class="flex justify-end gap-2">
+            <UButton variant="ghost" :label="$t('common.cancel')" @click="editOpen = false" />
+            <UButton
+              :loading="editing"
+              :label="$t('common.save')"
+              :disabled="!editInterval"
+              @click="onEdit()"
+            />
+          </div>
+        </div>
+      </template>
+    </UModal>
   </AppPage>
 </template>

--- a/app/utils/scheduleInterval.ts
+++ b/app/utils/scheduleInterval.ts
@@ -1,0 +1,29 @@
+// "week" is excluded on purpose: Temporal cannot total weeks exactly, and
+// aperture stores microseconds.
+export const INTERVAL_UNITS = ["second", "minute", "hour", "day"] as const;
+
+export type IntervalUnit = (typeof INTERVAL_UNITS)[number];
+
+export interface IntervalUnitCombo {
+  value: number;
+  unit: IntervalUnit;
+}
+
+export function unitComboToDuration(combo: IntervalUnitCombo): Temporal.Duration {
+  return Temporal.Duration.from({ [`${combo.unit}s`]: combo.value });
+}
+
+/**
+ * Expresses a duration as a whole number of the largest unit that divides it
+ * evenly (PT1H30M becomes 90 minutes). Returns undefined for durations below
+ * one second, which have no clean unit representation in the combo input.
+ */
+export function durationToUnitCombo(duration: Temporal.Duration): IntervalUnitCombo | undefined {
+  for (const unit of [...INTERVAL_UNITS].reverse()) {
+    const total = duration.total(unit);
+    if (total >= 1 && Number.isInteger(total)) {
+      return { value: total, unit };
+    }
+  }
+  return undefined;
+}

--- a/e2e/schedules.spec.ts
+++ b/e2e/schedules.spec.ts
@@ -1,0 +1,192 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { expect, test } from "@playwright/test";
+
+function iso(msFromNow: number): string {
+  return new Temporal.Instant(
+    BigInt(Temporal.Now.instant().epochMilliseconds + msFromNow) * 1_000_000n,
+  ).toString();
+}
+
+const stubSchedule = {
+  id: "sched-1",
+  kind: "download",
+  input: {
+    key: "firmware",
+    source: {
+      type: "oci",
+      reference: "ghcr.io/org/firmware:1",
+      media_type: "application/vnd.oci.image.layer.v1.tar",
+    },
+  },
+  interval: "PT5M",
+  next_run_at: iso(60_000),
+  enabled: true,
+  created_at: iso(-3_600_000),
+  last_run_at: null,
+  last_task_id: null,
+};
+
+const downloadDefinition = {
+  kind: "download",
+  cancellable: true,
+  resumable: false,
+  input_schema: {
+    type: "object",
+    required: ["key", "source"],
+    properties: {
+      key: { type: "string", description: "Logical key to record the artifact under." },
+      source: {
+        oneOf: [
+          {
+            type: "object",
+            required: ["reference", "media_type", "type"],
+            properties: {
+              reference: { type: "string" },
+              media_type: { type: "string" },
+              type: { type: "string", enum: ["oci"] },
+            },
+          },
+        ],
+      },
+    },
+  },
+  output_schema: { type: "object" },
+};
+
+function stubSchedulesApi(
+  page: import("@playwright/test").Page,
+  captured: { patches: unknown[]; creates: unknown[] },
+) {
+  return page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const pathname = url.pathname;
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/task-definitions") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([downloadDefinition]),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/task-schedules/sched-1") {
+      captured.patches.push(request.postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(stubSchedule),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/task-schedules" && request.method() === "POST") {
+      captured.creates.push(request.postDataJSON());
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify(stubSchedule),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/task-schedules") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [stubSchedule], next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+}
+
+test("schedules list renders and toggling fires a patch", async ({ page }) => {
+  const captured = { patches: [] as unknown[], creates: [] as unknown[] };
+  await stubSchedulesApi(page, captured);
+
+  await page.goto("/en/operations/schedules", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByRole("heading", { name: "Schedules" })).toBeVisible();
+  await expect(page.getByText("download", { exact: true })).toBeVisible();
+  await expect(page.getByText("5 min", { exact: true })).toBeVisible();
+  // The input renders through the schema-driven viewer.
+  await expect(page.getByTitle("Logical key to record the artifact under.")).toBeVisible();
+
+  await page.getByRole("switch").click();
+  await expect.poll(() => captured.patches.length).toBe(1);
+  expect(captured.patches[0]).toEqual({ enabled: false });
+});
+
+test("create schedule posts kind, schema-driven input, and interval", async ({ page }) => {
+  const captured = { patches: [] as unknown[], creates: [] as unknown[] };
+  await stubSchedulesApi(page, captured);
+
+  await page.goto("/en/operations/schedules", { waitUntil: "domcontentloaded" });
+
+  await page.getByRole("button", { name: "New schedule" }).click();
+
+  const typeStable = async (name: string, value: string) => {
+    const box = page.getByRole("textbox", { name });
+    await box.click();
+    await page.keyboard.type(value, { delay: 20 });
+    await expect(box).toHaveValue(value);
+  };
+
+  await typeStable("key", "firmware");
+  await typeStable("reference", "ghcr.io/org/firmware:2");
+  await typeStable("media_type", "application/vnd.oci.image.layer.v1.tar");
+
+  const number = page.getByRole("spinbutton");
+  await number.click();
+  await page.keyboard.type("10", { delay: 20 });
+  await expect(number).toHaveValue("10");
+
+  await page.getByRole("button", { name: "Create" }).click();
+
+  await expect.poll(() => captured.creates.length).toBe(1);
+  expect(captured.creates[0]).toEqual({
+    kind: "download",
+    input: {
+      key: "firmware",
+      source: {
+        type: "oci",
+        reference: "ghcr.io/org/firmware:2",
+        media_type: "application/vnd.oci.image.layer.v1.tar",
+      },
+    },
+    interval: "PT10M",
+  });
+});

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -16,8 +16,15 @@
     "noParameters": "Keine Parameter.",
     "notImplemented": "Noch nicht implementiert.",
     "prev": "Zurück",
+    "save": "Speichern",
     "rawJson": "JSON-Rohdaten",
-    "retry": "Erneut versuchen"
+    "retry": "Erneut versuchen",
+    "durationUnits": {
+      "second": "Sekunden",
+      "minute": "Minuten",
+      "hour": "Stunden",
+      "day": "Tage"
+    }
   },
   "auth": {
     "roles": {
@@ -266,7 +273,24 @@
       }
     },
     "schedules": {
-      "title": "Zeitpläne"
+      "title": "Zeitpläne",
+      "empty": "Keine Zeitpläne gefunden.",
+      "error": "Zeitpläne konnten nicht geladen werden.",
+      "refresh": "Aktualisieren",
+      "create": "Neuer Zeitplan",
+      "created": "Zeitplan erstellt.",
+      "createFailed": "Zeitplan konnte nicht erstellt werden.",
+      "invalidInterval": "Gib ein gültiges Intervall ein.",
+      "edit": "Zeitplan bearbeiten",
+      "edited": "Zeitplan aktualisiert.",
+      "updateFailed": "Zeitplan konnte nicht aktualisiert werden.",
+      "deleted": "Zeitplan gelöscht.",
+      "deleteFailed": "Zeitplan konnte nicht gelöscht werden.",
+      "interval": "Intervall",
+      "nextRun": "Nächste Ausführung",
+      "lastRun": "Letzte Ausführung",
+      "never": "Nie",
+      "input": "Eingabe"
     },
     "artifacts": {
       "title": "Artefakte"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -16,8 +16,15 @@
     "noParameters": "No parameters.",
     "notImplemented": "Not implemented yet.",
     "prev": "Previous",
+    "save": "Save",
     "rawJson": "Raw JSON",
-    "retry": "Retry"
+    "retry": "Retry",
+    "durationUnits": {
+      "second": "seconds",
+      "minute": "minutes",
+      "hour": "hours",
+      "day": "days"
+    }
   },
   "auth": {
     "roles": {
@@ -266,7 +273,24 @@
       }
     },
     "schedules": {
-      "title": "Schedules"
+      "title": "Schedules",
+      "empty": "No schedules found.",
+      "error": "Failed to load schedules.",
+      "refresh": "Refresh",
+      "create": "New schedule",
+      "created": "Schedule created.",
+      "createFailed": "Failed to create the schedule.",
+      "invalidInterval": "Enter a valid interval.",
+      "edit": "Edit schedule",
+      "edited": "Schedule updated.",
+      "updateFailed": "Failed to update the schedule.",
+      "deleted": "Schedule deleted.",
+      "deleteFailed": "Failed to delete the schedule.",
+      "interval": "Interval",
+      "nextRun": "Next run",
+      "lastRun": "Last run",
+      "never": "Never",
+      "input": "Input"
     },
     "artifacts": {
       "title": "Artifacts"

--- a/test/scheduleInterval.test.ts
+++ b/test/scheduleInterval.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  durationToUnitCombo,
+  unitComboToDuration,
+  type IntervalUnitCombo,
+} from "~/utils/scheduleInterval";
+
+describe("unitComboToDuration", () => {
+  it("builds a duration from value and unit", () => {
+    expect(unitComboToDuration({ value: 5, unit: "minute" }).toString()).toBe("PT5M");
+    expect(unitComboToDuration({ value: 2, unit: "hour" }).toString()).toBe("PT2H");
+    expect(unitComboToDuration({ value: 90, unit: "second" }).toString()).toBe("PT90S");
+    expect(unitComboToDuration({ value: 3, unit: "day" }).toString()).toBe("P3D");
+  });
+});
+
+describe("durationToUnitCombo", () => {
+  it("round-trips simple durations", () => {
+    const combo: IntervalUnitCombo = { value: 5, unit: "minute" };
+    expect(durationToUnitCombo(unitComboToDuration(combo))).toEqual(combo);
+  });
+
+  it("picks the largest unit that divides evenly", () => {
+    expect(durationToUnitCombo(Temporal.Duration.from("PT1H30M"))).toEqual({
+      value: 90,
+      unit: "minute",
+    });
+    expect(durationToUnitCombo(Temporal.Duration.from("P2D"))).toEqual({
+      value: 2,
+      unit: "day",
+    });
+    expect(durationToUnitCombo(Temporal.Duration.from("PT48H"))).toEqual({
+      value: 2,
+      unit: "day",
+    });
+  });
+
+  it("returns undefined below one second", () => {
+    expect(durationToUnitCombo(Temporal.Duration.from("PT0.5S"))).toBeUndefined();
+    expect(durationToUnitCombo(Temporal.Duration.from({ milliseconds: 200 }))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Lists periodic task schedules with cursor paging, a schema-driven
read-only view of each schedule's input, an optimistic enable switch
(PATCH), last-run links into the task detail, and edit and delete
actions. Create and edit use a new IntervalInput component exposing a
Temporal.Duration (whole number plus unit), and SchemaForm for the
kind input.

Also fixes number fields in SchemaForm: UInput with type number emits
numbers, which the string-based zod validation and state cleanup
expected.