### PR TITLE
feat: artifacts page

### DIFF
--- a/app/composables/useArtifactsFilters.ts
+++ b/app/composables/useArtifactsFilters.ts
@@ -1,0 +1,61 @@
+import * as z from "zod/v4/mini";
+import type {
+  ListArtifactVersionsParams,
+  ListArtifactsParams,
+} from "~~/modules/aperture/runtime/types";
+import { queryOptionalString, useRouteQueryState } from "~/composables/useRouteQueryState";
+
+export const ARTIFACT_SORTS = ["downloaded_at", "size_bytes"] as const;
+
+export type ArtifactSort = (typeof ARTIFACT_SORTS)[number];
+
+function isArtifactSort(value: string): value is ArtifactSort {
+  return (ARTIFACT_SORTS as readonly string[]).includes(value);
+}
+
+const querySort = z.codec(z.array(z.string()), z.custom<ArtifactSort | undefined>(), {
+  decode: (arr) => {
+    const v = arr[0];
+    return v !== undefined && isArtifactSort(v) ? v : undefined;
+  },
+  encode: (v) => (v ? [v] : []),
+});
+
+const artifactsSchema = z.object({
+  q: queryOptionalString(),
+  key: queryOptionalString(),
+});
+
+export type ArtifactsFilters = z.infer<typeof artifactsSchema>;
+
+export function useArtifactsFilters(): ArtifactsFilters {
+  return useRouteQueryState(artifactsSchema);
+}
+
+export function artifactsParamsFromFilters(filters: ArtifactsFilters): ListArtifactsParams {
+  const p: ListArtifactsParams = {};
+  if (filters.q) p.q = filters.q;
+  return p;
+}
+
+const versionsSchema = z.object({
+  media_type: queryOptionalString(),
+  version: queryOptionalString(),
+  sort: querySort,
+});
+
+export type ArtifactVersionsFilters = z.infer<typeof versionsSchema>;
+
+export function useArtifactVersionsFilters(): ArtifactVersionsFilters {
+  return useRouteQueryState(versionsSchema);
+}
+
+export function versionsParamsFromFilters(
+  filters: ArtifactVersionsFilters,
+): ListArtifactVersionsParams {
+  const p: ListArtifactVersionsParams = {};
+  if (filters.media_type) p.media_type = filters.media_type;
+  if (filters.version) p.version = filters.version;
+  if (filters.sort) p.sort = filters.sort;
+  return p;
+}

--- a/app/pages/operations/artifacts.vue
+++ b/app/pages/operations/artifacts.vue
@@ -1,5 +1,360 @@
+<script setup lang="ts">
+import type { SelectMenuItem } from "@nuxt/ui";
+import type {
+  ArtifactSummary,
+  ArtifactVersion,
+  ListArtifactsParams,
+  ListArtifactVersionsParams,
+} from "~~/modules/aperture/runtime/types";
+import {
+  artifactsParamsFromFilters,
+  useArtifactsFilters,
+  useArtifactVersionsFilters,
+  versionsParamsFromFilters,
+} from "~/composables/useArtifactsFilters";
+import { bytesToUnit } from "~/utils/formatBytes";
+
+const { t } = useI18n();
+const toast = useToast();
+const fmt = useFormatter();
+
+const filters = useArtifactsFilters();
+const versionFilters = useArtifactVersionsFilters();
+
+function formatTimestamp(ts: Temporal.Instant): string {
+  return fmt.date(ts, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatBytes(bytes: number): string {
+  const { value, unit } = bytesToUnit(bytes);
+  return fmt.unit(value, unit as Parameters<typeof fmt.unit>[1], { unitDisplay: "short" });
+}
+
+function shortDigest(digest: string): string {
+  return digest.length > 19 ? `${digest.slice(0, 19)}...` : digest;
+}
+
+// List view.
+
+const listParams = computed(() => artifactsParamsFromFilters(filters));
+
+const {
+  items: artifacts,
+  pending: listPending,
+  error: listError,
+  hasNext: listHasNext,
+  hasPrev: listHasPrev,
+  loadNext: listLoadNext,
+  loadPrev: listLoadPrev,
+  reload: listReload,
+} = useCursorPager<ArtifactSummary, ListArtifactsParams>(
+  (query) => apertureApi.listArtifacts(query),
+  () => listParams.value,
+);
+
+const selectedKey = computed(() => filters.key);
+
+function openKey(key: string) {
+  filters.key = key;
+  versionFilters.media_type = undefined;
+  versionFilters.version = undefined;
+  versionFilters.sort = undefined;
+}
+
+// Versions view.
+
+const versionsParams = computed<ListArtifactVersionsParams>(() =>
+  versionsParamsFromFilters(versionFilters),
+);
+
+const {
+  items: versions,
+  pending: versionsPending,
+  error: versionsError,
+  hasNext: versionsHasNext,
+  hasPrev: versionsHasPrev,
+  loadNext: versionsLoadNext,
+  loadPrev: versionsLoadPrev,
+  reload: versionsReload,
+} = useCursorPager<ArtifactVersion, ListArtifactVersionsParams>(
+  (query) => apertureApi.listArtifactVersions(selectedKey.value ?? "", query),
+  () => (selectedKey.value ? versionsParams.value : undefined),
+);
+
+const sortItems = computed<SelectMenuItem[]>(() => [
+  { label: t("operations.artifacts.sort.downloadedAt"), value: "downloaded_at" },
+  { label: t("operations.artifacts.sort.sizeBytes"), value: "size_bytes" },
+]);
+
+async function onEvict(version: ArtifactVersion) {
+  if (!selectedKey.value) return;
+  try {
+    await apertureApi.deleteArtifactVersion(selectedKey.value, version.digest);
+    await versionsReload();
+    toast.add({ title: t("operations.artifacts.evicted"), color: "success" });
+  } catch (err) {
+    toast.add({
+      title:
+        err instanceof ApiError && err.status === 404
+          ? t("operations.artifacts.evictMissing")
+          : t("operations.artifacts.evictFailed"),
+      color: "error",
+    });
+  }
+}
+
+function downloadName(version: ArtifactVersion): string {
+  if (version.version) return version.version;
+  return version.digest.replace(":", "-");
+}
+
+// Upload modal.
+
+const uploadOpen = ref(false);
+const uploadKey = ref("");
+const uploadFile = ref<File | null>(null);
+const uploading = ref(false);
+
+function openUpload(key?: string) {
+  uploadKey.value = key ?? "";
+  uploadFile.value = null;
+  uploadOpen.value = true;
+}
+
+function onUploadFileChange(event: Event) {
+  const target = event.target as HTMLInputElement;
+  uploadFile.value = target.files?.[0] ?? null;
+}
+
+async function onUpload() {
+  if (!uploadKey.value.trim() || !uploadFile.value) return;
+  uploading.value = true;
+  try {
+    await apertureApi.uploadArtifact(uploadKey.value.trim(), uploadFile.value);
+    uploadOpen.value = false;
+    toast.add({ title: t("operations.artifacts.uploaded"), color: "success" });
+    if (selectedKey.value && selectedKey.value === uploadKey.value.trim()) {
+      await versionsReload();
+    } else {
+      await listReload();
+    }
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 413) {
+      toast.add({ title: t("operations.artifacts.tooLarge"), color: "error" });
+    } else {
+      toast.add({ title: t("operations.artifacts.uploadFailed"), color: "error" });
+    }
+  } finally {
+    uploading.value = false;
+  }
+}
+</script>
+
 <template>
   <AppPage :title="$t('operations.artifacts.title')">
-    <div class="p-6 text-muted">{{ $t("common.notImplemented") }}</div>
+    <template #toolbar>
+      <div class="flex flex-wrap items-center gap-2 px-4 py-2 border-b border-default">
+        <template v-if="!selectedKey">
+          <UInput
+            v-model="filters.q"
+            :placeholder="$t('operations.artifacts.search')"
+            icon="i-lucide-search"
+            size="sm"
+            class="w-56"
+          />
+        </template>
+        <template v-else>
+          <UButton
+            icon="i-lucide-arrow-left"
+            color="neutral"
+            variant="ghost"
+            size="sm"
+            :label="$t('operations.artifacts.backToList')"
+            @click="filters.key = undefined"
+          />
+          <span class="font-mono text-sm truncate">{{ selectedKey }}</span>
+          <UInput
+            v-model="versionFilters.media_type"
+            :placeholder="$t('operations.artifacts.filters.mediaType')"
+            size="sm"
+            class="w-56"
+          />
+          <UInput
+            v-model="versionFilters.version"
+            :placeholder="$t('operations.artifacts.filters.version')"
+            size="sm"
+            class="w-36"
+          />
+          <USelectMenu
+            v-model="versionFilters.sort"
+            :items="sortItems"
+            value-key="value"
+            size="sm"
+            class="w-44"
+          />
+        </template>
+
+        <UButton
+          variant="ghost"
+          color="neutral"
+          icon="i-lucide-refresh-cw"
+          size="sm"
+          :label="$t('operations.artifacts.refresh')"
+          class="ms-auto"
+          @click="selectedKey ? versionsReload() : listReload()"
+        />
+        <UButton
+          icon="i-lucide-upload"
+          size="sm"
+          :label="$t('operations.artifacts.upload')"
+          @click="openUpload(selectedKey)"
+        />
+      </div>
+    </template>
+
+    <div class="p-4">
+      <DataState
+        v-if="!selectedKey"
+        :pending="listPending && artifacts.length === 0"
+        :error="listError ? String(listError) : null"
+        :empty="artifacts.length === 0"
+        :empty-text="$t('operations.artifacts.empty')"
+        :error-text="$t('operations.artifacts.error')"
+        :retry-text="$t('common.retry')"
+        @retry="listReload()"
+      >
+        <div class="flex flex-col gap-2">
+          <UPageCard
+            v-for="artifact in artifacts"
+            :key="artifact.key"
+            variant="subtle"
+            class="cursor-pointer"
+            @click="openKey(artifact.key)"
+          >
+            <div class="flex flex-wrap sm:items-center justify-between gap-3">
+              <div class="flex items-center gap-3 min-w-0">
+                <UIcon name="i-lucide-package" class="size-4 text-muted shrink-0" />
+                <span class="font-mono text-sm truncate">{{ artifact.key }}</span>
+                <UBadge
+                  :label="$t('operations.artifacts.versionCount', { n: artifact.version_count })"
+                  variant="subtle"
+                />
+              </div>
+              <div class="flex items-center gap-3 text-xs text-muted">
+                <span v-if="artifact.version" class="font-mono">{{ artifact.version }}</span>
+                <span class="font-mono" :title="artifact.digest">
+                  {{ shortDigest(artifact.digest) }}
+                </span>
+                <span>{{ formatBytes(artifact.size_bytes) }}</span>
+                <span>{{ formatTimestamp(artifact.downloaded_at) }}</span>
+              </div>
+            </div>
+          </UPageCard>
+        </div>
+
+        <PagerBar
+          :has-prev="listHasPrev"
+          :has-next="listHasNext"
+          :pending="listPending && artifacts.length === 0"
+          :prev-text="$t('common.prev')"
+          :next-text="$t('common.next')"
+          @prev="listLoadPrev()"
+          @next="listLoadNext()"
+        />
+      </DataState>
+
+      <DataState
+        v-else
+        :pending="versionsPending && versions.length === 0"
+        :error="versionsError ? String(versionsError) : null"
+        :empty="versions.length === 0"
+        :empty-text="$t('operations.artifacts.noVersions')"
+        :error-text="$t('operations.artifacts.error')"
+        :retry-text="$t('common.retry')"
+        @retry="versionsReload()"
+      >
+        <div class="flex flex-col gap-2">
+          <UPageCard v-for="version in versions" :key="version.digest" variant="subtle">
+            <div class="flex flex-wrap sm:items-center justify-between gap-3">
+              <div class="flex flex-col min-w-0">
+                <span class="font-mono text-xs" :title="version.digest">
+                  {{ version.digest }}
+                </span>
+                <span class="text-muted text-xs">
+                  <template v-if="version.version">{{ version.version }} · </template>
+                  <template v-if="version.media_type">{{ version.media_type }} · </template>
+                  {{ formatBytes(version.size_bytes) }}
+                </span>
+              </div>
+              <div class="flex items-center gap-3 text-xs text-muted">
+                <span>{{ formatTimestamp(version.downloaded_at) }}</span>
+                <span v-if="version.verified_at">
+                  {{ $t("operations.artifacts.verified") }}:
+                  {{ formatTimestamp(version.verified_at) }}
+                </span>
+                <UButton
+                  icon="i-lucide-download"
+                  color="neutral"
+                  variant="ghost"
+                  size="xs"
+                  :label="$t('operations.artifacts.download')"
+                  :to="artifactBlobUrl(selectedKey, version.digest)"
+                  :download="downloadName(version)"
+                  external
+                />
+                <UButton
+                  icon="i-lucide-trash"
+                  color="error"
+                  variant="ghost"
+                  size="xs"
+                  :aria-label="$t('operations.artifacts.evict')"
+                  @click="onEvict(version)"
+                />
+              </div>
+            </div>
+          </UPageCard>
+        </div>
+
+        <PagerBar
+          :has-prev="versionsHasPrev"
+          :has-next="versionsHasNext"
+          :pending="versionsPending && versions.length === 0"
+          :prev-text="$t('common.prev')"
+          :next-text="$t('common.next')"
+          @prev="versionsLoadPrev()"
+          @next="versionsLoadNext()"
+        />
+      </DataState>
+    </div>
+
+    <UModal v-model:open="uploadOpen" :title="$t('operations.artifacts.upload')">
+      <template #body>
+        <div class="flex flex-col gap-4">
+          <UFormField :label="$t('operations.artifacts.key')" name="key">
+            <UInput v-model="uploadKey" :disabled="!!selectedKey" class="w-full font-mono" />
+          </UFormField>
+
+          <UFormField :label="$t('operations.artifacts.file')" name="file">
+            <UInput type="file" class="w-full" @change="onUploadFileChange" />
+          </UFormField>
+
+          <div class="flex justify-end gap-2">
+            <UButton variant="ghost" :label="$t('common.cancel')" @click="uploadOpen = false" />
+            <UButton
+              :loading="uploading"
+              :label="$t('operations.artifacts.upload')"
+              :disabled="!uploadKey.trim() || !uploadFile"
+              @click="onUpload()"
+            />
+          </div>
+        </div>
+      </template>
+    </UModal>
   </AppPage>
 </template>

--- a/app/utils/formatBytes.ts
+++ b/app/utils/formatBytes.ts
@@ -1,0 +1,17 @@
+import type { SimpleUnit } from "~~/modules/format/runtime/types";
+
+const UNITS: readonly SimpleUnit[] = ["byte", "kilobyte", "megabyte", "gigabyte", "terabyte"];
+
+/**
+ * Picks the byte-multiple unit (base 1000) that shows the value with at
+ * least one digit before the decimal point.
+ */
+export function bytesToUnit(bytes: number): { value: number; unit: SimpleUnit } {
+  let value = bytes;
+  let unitIndex = 0;
+  while (unitIndex < UNITS.length - 1 && Math.abs(value) >= 1000) {
+    value /= 1000;
+    unitIndex++;
+  }
+  return { value, unit: UNITS[unitIndex]! };
+}

--- a/e2e/artifacts.spec.ts
+++ b/e2e/artifacts.spec.ts
@@ -1,0 +1,208 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { expect, test } from "@playwright/test";
+
+function iso(msAgo: number): string {
+  return new Temporal.Instant(
+    BigInt(Temporal.Now.instant().epochMilliseconds - msAgo) * 1_000_000n,
+  ).toString();
+}
+
+const stubArtifacts = [
+  {
+    key: "spectra",
+    version: "2026.8.3",
+    version_count: 3,
+    digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    size_bytes: 2_500_000,
+    source: "oci:ghcr.io/stargrid-systems/spectra:2026.8.3",
+    downloaded_at: iso(3_600_000),
+  },
+];
+
+const stubVersions = [
+  {
+    key: "spectra",
+    digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    version: "2026.8.3",
+    media_type: "application/vnd.oci.image.layer.v1.tar",
+    size_bytes: 2_500_000,
+    source: "oci:ghcr.io/stargrid-systems/spectra:2026.8.3",
+    downloaded_at: iso(3_600_000),
+    verified_at: null,
+  },
+];
+
+test("artifacts list, versions view, download, and evict", async ({ page }) => {
+  const captured = { listQueries: [] as string[], deletes: [] as string[] };
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const pathname = decodeURIComponent(url.pathname);
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/artifacts" && request.method() === "GET") {
+      captured.listQueries.push(url.search);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: stubArtifacts, next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/artifacts/spectra/versions") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: stubVersions, next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    const evictPattern = /^\/api\/v1\/artifacts\/spectra\/versions\/(.+)$/;
+    const evictMatch = pathname.match(evictPattern);
+    if (evictMatch && request.method() === "DELETE") {
+      captured.deletes.push(evictMatch[1]!);
+      await route.fulfill({ status: 204 });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.goto("/en/operations/artifacts", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByRole("heading", { name: "Artifacts" })).toBeVisible();
+  await expect(page.getByText("spectra", { exact: true })).toBeVisible();
+  await expect(page.getByText("3 versions")).toBeVisible();
+
+  // Open the versions view for the key.
+  await page.getByText("spectra", { exact: true }).click();
+  await expect(page).toHaveURL(/key=spectra/);
+  await expect(
+    page.getByText("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+  ).toBeVisible();
+  await expect(page.getByText("application/vnd.oci.image.layer.v1.tar")).toBeVisible();
+
+  // Download is a plain link to the blob endpoint.
+  const download = page.getByRole("link", { name: "Download" });
+  await expect(download).toHaveAttribute(
+    "href",
+    "/api/v1/artifacts/spectra/versions/sha256%3A0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/blob",
+  );
+
+  // Evict fires the DELETE against the digest.
+  await page.getByRole("button", { name: "Evict" }).click();
+  await expect.poll(() => captured.deletes.length).toBe(1);
+  expect(captured.deletes[0]).toMatch(/^sha256/);
+});
+
+test("upload posts the file body under the key", async ({ page }) => {
+  const captured = { uploads: [] as { key: string; body: string }[] };
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const pathname = decodeURIComponent(url.pathname);
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    const uploadMatch = pathname.match(/^\/api\/v1\/artifacts\/([^/]+)$/);
+    if (uploadMatch && request.method() === "PUT") {
+      captured.uploads.push({ key: uploadMatch[1]!, body: request.postData() ?? "" });
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify(stubVersions[0]),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/artifacts") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.goto("/en/operations/artifacts", { waitUntil: "domcontentloaded" });
+
+  // Wait for the app to finish hydrating before interacting.
+  await expect(page.getByText("No artifacts found.")).toBeVisible();
+  await page.getByRole("button", { name: "Upload" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("textbox", { name: "Key", exact: true }).fill("firmware");
+  await dialog.locator('input[type="file"]').setInputFiles({
+    name: "fw.bin",
+    mimeType: "application/octet-stream",
+    buffer: Buffer.from("firmware-bytes"),
+  });
+
+  await dialog.getByRole("button", { name: "Upload" }).click();
+
+  await expect.poll(() => captured.uploads.length).toBe(1);
+  expect(captured.uploads[0]).toEqual({ key: "firmware", body: "firmware-bytes" });
+});

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -269,7 +269,34 @@
       "title": "Zeitpläne"
     },
     "artifacts": {
-      "title": "Artefakte"
+      "title": "Artefakte",
+      "empty": "Keine Artefakte gefunden.",
+      "error": "Artefakte konnten nicht geladen werden.",
+      "refresh": "Aktualisieren",
+      "search": "Schlüssel suchen",
+      "upload": "Hochladen",
+      "uploaded": "Artefakt gespeichert.",
+      "uploadFailed": "Artefakt konnte nicht gespeichert werden.",
+      "tooLarge": "Die Datei überschreitet die maximale Größe.",
+      "key": "Schlüssel",
+      "file": "Datei",
+      "backToList": "Alle Artefakte",
+      "versionCount": "{n} Version | {n} Versionen",
+      "noVersions": "Für diesen Schlüssel sind keine Versionen gespeichert.",
+      "verified": "Verifiziert",
+      "download": "Herunterladen",
+      "evict": "Entfernen",
+      "evicted": "Version entfernt.",
+      "evictMissing": "Diese Version existiert nicht mehr.",
+      "evictFailed": "Version konnte nicht entfernt werden.",
+      "filters": {
+        "mediaType": "Medientyp",
+        "version": "Version"
+      },
+      "sort": {
+        "downloadedAt": "Zuletzt heruntergeladen",
+        "sizeBytes": "Größe"
+      }
     }
   },
   "units": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -269,7 +269,34 @@
       "title": "Schedules"
     },
     "artifacts": {
-      "title": "Artifacts"
+      "title": "Artifacts",
+      "empty": "No artifacts found.",
+      "error": "Failed to load artifacts.",
+      "refresh": "Refresh",
+      "search": "Search keys",
+      "upload": "Upload",
+      "uploaded": "Artifact stored.",
+      "uploadFailed": "Failed to store the artifact.",
+      "tooLarge": "The file exceeds the maximum upload size.",
+      "key": "Key",
+      "file": "File",
+      "backToList": "All artifacts",
+      "versionCount": "{n} version | {n} versions",
+      "noVersions": "No versions stored for this key.",
+      "verified": "Verified",
+      "download": "Download",
+      "evict": "Evict",
+      "evicted": "Version evicted.",
+      "evictMissing": "This version no longer exists.",
+      "evictFailed": "Failed to evict the version.",
+      "filters": {
+        "mediaType": "Media type",
+        "version": "Version"
+      },
+      "sort": {
+        "downloadedAt": "Newest downloaded",
+        "sizeBytes": "Size"
+      }
     }
   },
   "units": {

--- a/modules/aperture/runtime/client.ts
+++ b/modules/aperture/runtime/client.ts
@@ -56,6 +56,21 @@ import type {
 
 const client = createClient<paths>({
   querySerializer: { array: { style: "form", explode: false } },
+  // The default serializer JSON-stringifies everything but FormData, which
+  // would turn binary upload bodies into "{}".
+  bodySerializer(body: unknown) {
+    if (typeof body === "string") {
+      return body;
+    }
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      (body instanceof FormData || body instanceof Blob)
+    ) {
+      return body;
+    }
+    return JSON.stringify(body);
+  },
 });
 
 export class ApiError extends Error {

--- a/test/formatBytes.test.ts
+++ b/test/formatBytes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { bytesToUnit } from "~/utils/formatBytes";
+
+describe("bytesToUnit", () => {
+  it("keeps small values in bytes", () => {
+    expect(bytesToUnit(0)).toEqual({ value: 0, unit: "byte" });
+    expect(bytesToUnit(42)).toEqual({ value: 42, unit: "byte" });
+    expect(bytesToUnit(999)).toEqual({ value: 999, unit: "byte" });
+  });
+
+  it("scales up in steps of 1000", () => {
+    expect(bytesToUnit(1000)).toEqual({ value: 1, unit: "kilobyte" });
+    expect(bytesToUnit(1500)).toEqual({ value: 1.5, unit: "kilobyte" });
+    expect(bytesToUnit(1_000_000)).toEqual({ value: 1, unit: "megabyte" });
+    expect(bytesToUnit(2_500_000_000)).toEqual({ value: 2.5, unit: "gigabyte" });
+    expect(bytesToUnit(3_000_000_000_000)).toEqual({ value: 3, unit: "terabyte" });
+  });
+
+  it("caps at terabyte", () => {
+    expect(bytesToUnit(5_000_000_000_000_000)).toEqual({ value: 5000, unit: "terabyte" });
+  });
+});


### PR DESCRIPTION
Artifact keys as a searchable, paginated list with size and newest
version, a URL-shareable versions browser per key (?key=) with
media-type, version, and sort filters, direct blob downloads through
the immutable blob URL, evict, and an upload modal.

Also fixes binary upload bodies: openapi-fetch's default body
serializer JSON-stringifies everything but FormData, turning File
uploads into "{}". The aperture client now passes Blob and string
bodies through unchanged.