### PR TITLE
feat: system settings page

### DIFF
--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -39,6 +39,11 @@ const links = computed(
                 icon: "i-lucide-users",
                 to: localePath("/settings/users"),
               },
+              {
+                label: t("settings.nav.system"),
+                icon: "i-lucide-server",
+                to: localePath("/settings/system"),
+              },
             ]
           : []),
       ],

--- a/app/pages/settings/system.vue
+++ b/app/pages/settings/system.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import type { Setting } from "~~/modules/aperture/runtime/types";
+
+const { t } = useI18n();
+const toast = useToast();
+const { isAdmin } = useAuth();
+
+const { data, pending, error, refresh } = await useAsyncData<Setting[]>(
+  "settings",
+  () => apertureApi.listSettings(),
+  { server: false },
+);
+
+function valuePreview(value: unknown): string {
+  return JSON.stringify(value) ?? "null";
+}
+
+// Edit modal with a JSON editor; values are arbitrary JSON, so the text is
+// parsed before sending and the server's 400 is surfaced inline.
+
+const editOpen = ref(false);
+const editKey = ref("");
+const editText = ref("");
+const editError = ref<string | null>(null);
+const saving = ref(false);
+
+function openEdit(setting: Setting) {
+  editKey.value = setting.key;
+  editText.value = JSON.stringify(setting.value, null, 2) ?? "null";
+  editError.value = null;
+  editOpen.value = true;
+}
+
+async function onSave() {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(editText.value);
+  } catch {
+    editError.value = t("settings.system.invalidJson");
+    return;
+  }
+  editError.value = null;
+  saving.value = true;
+  try {
+    await apertureApi.updateSetting(editKey.value, { value: parsed });
+    editOpen.value = false;
+    toast.add({ title: t("settings.system.saved"), color: "success" });
+    await refresh();
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 400) {
+      editError.value = t("settings.system.rejectedValue");
+    } else if (err instanceof ApiError && err.status === 404) {
+      editError.value = t("settings.system.missingKey");
+    } else {
+      toast.add({ title: t("settings.system.saveFailed"), color: "error" });
+    }
+  } finally {
+    saving.value = false;
+  }
+}
+</script>
+
+<template>
+  <div>
+    <UPageCard
+      :title="$t('settings.system.title')"
+      :description="$t('settings.system.description')"
+      variant="naked"
+      orientation="horizontal"
+      class="mb-4"
+    />
+
+    <p v-if="!isAdmin" class="text-muted text-sm mb-4">
+      {{ $t("settings.system.adminOnly") }}
+    </p>
+
+    <DataState
+      :pending="pending"
+      :error="error ? String(error) : null"
+      :empty="!data?.length"
+      :empty-text="$t('settings.system.empty')"
+      :error-text="$t('settings.system.error')"
+      :retry-text="$t('common.retry')"
+      @retry="refresh()"
+    >
+      <div class="flex flex-col gap-2">
+        <UPageCard v-for="setting in data" :key="setting.key" variant="subtle">
+          <div class="flex sm:items-center justify-between gap-3">
+            <div class="flex flex-col min-w-0">
+              <span class="font-mono text-sm truncate">{{ setting.key }}</span>
+              <span
+                class="text-muted text-xs font-mono truncate"
+                :title="valuePreview(setting.value)"
+              >
+                {{ valuePreview(setting.value) }}
+              </span>
+            </div>
+            <UButton
+              v-if="isAdmin"
+              icon="i-lucide-pencil"
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              :aria-label="$t('settings.system.edit')"
+              @click="openEdit(setting)"
+            />
+          </div>
+        </UPageCard>
+      </div>
+    </DataState>
+
+    <UModal v-model:open="editOpen" :title="editKey">
+      <template #body>
+        <div class="flex flex-col gap-4">
+          <UFormField
+            :label="$t('settings.system.value')"
+            :error="editError ?? undefined"
+            name="value"
+          >
+            <UTextarea
+              v-model="editText"
+              :rows="8"
+              class="w-full font-mono text-xs"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </UFormField>
+
+          <div class="flex justify-end gap-2">
+            <UButton variant="ghost" :label="$t('common.cancel')" @click="editOpen = false" />
+            <UButton :loading="saving" :label="$t('common.save')" @click="onSave()" />
+          </div>
+        </div>
+      </template>
+    </UModal>
+  </div>
+</template>

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+
+const stubSettings = [
+  { key: "aperture.avatar.style", value: "constellation" },
+  { key: "aperture.log.level", value: { min_level: "info", format: "json" } },
+];
+
+function stubSettingsApi(
+  page: import("@playwright/test").Page,
+  captured: { puts: { key: string; body: unknown }[] },
+) {
+  return page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const pathname = url.pathname;
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    const putMatch = pathname.match(/^\/api\/v1\/settings\/(.+)$/);
+    if (putMatch && request.method() === "PUT") {
+      captured.puts.push({ key: decodeURIComponent(putMatch[1]!), body: request.postDataJSON() });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          key: putMatch[1],
+          value: request.postDataJSON()?.value ?? null,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/settings") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(stubSettings),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+}
+
+test("system settings list and JSON editor", async ({ page }) => {
+  const captured = { puts: [] as { key: string; body: unknown }[] };
+  await stubSettingsApi(page, captured);
+
+  await page.goto("/en/settings/system", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByText("System settings", { exact: true })).toBeVisible();
+  await expect(page.getByText("aperture.avatar.style", { exact: true })).toBeVisible();
+  await expect(page.getByText('"constellation"')).toBeVisible();
+
+  // Open the editor for the object-valued setting.
+  await page
+    .locator("div")
+    .filter({ hasText: /^aperture\.log\.level/ })
+    .getByRole("button", { name: "Edit setting" })
+    .click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+
+  // Invalid JSON is caught client-side and never sent.
+  const editor = dialog.locator("textarea");
+  await editor.fill("{ not json");
+  await dialog.getByRole("button", { name: "Save" }).click();
+  await expect(dialog.getByText("The text is not valid JSON.")).toBeVisible();
+  expect(captured.puts).toHaveLength(0);
+
+  // A valid edit parses and PUTs the typed JSON.
+  await editor.fill('{"min_level":"debug","format":"json"}');
+  await dialog.getByRole("button", { name: "Save" }).click();
+
+  await expect.poll(() => captured.puts.length).toBe(1);
+  expect(captured.puts[0]).toEqual({
+    key: "aperture.log.level",
+    body: { value: { min_level: "debug", format: "json" } },
+  });
+});

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -112,7 +112,8 @@
       "about": "Info",
       "account": "Konto",
       "apiKeys": "API-Schlüssel",
-      "users": "Benutzer"
+      "users": "Benutzer",
+      "system": "System"
     },
     "sections": {
       "dashboard": {
@@ -137,6 +138,20 @@
         "spectraVersion": "Spectra-Version",
         "apertureVersion": "Aperture-Version"
       }
+    },
+    "system": {
+      "title": "Systemeinstellungen",
+      "description": "Konfigurationsschlüssel des Gateways und ihre aktuellen Werte.",
+      "adminOnly": "Nur Administratoren können Systemeinstellungen sehen und ändern.",
+      "empty": "Keine Einstellungen verfügbar.",
+      "error": "Einstellungen konnten nicht geladen werden.",
+      "edit": "Einstellung bearbeiten",
+      "value": "Wert (JSON)",
+      "invalidJson": "Der Text ist kein gültiges JSON.",
+      "rejectedValue": "Der Gateway hat diesen Wert abgelehnt.",
+      "missingKey": "Dieser Konfigurationsschlüssel existiert nicht mehr.",
+      "saved": "Einstellung gespeichert.",
+      "saveFailed": "Einstellung konnte nicht gespeichert werden."
     }
   },
   "developer": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -112,7 +112,8 @@
       "about": "About",
       "account": "Account",
       "apiKeys": "API keys",
-      "users": "Users"
+      "users": "Users",
+      "system": "System"
     },
     "sections": {
       "dashboard": {
@@ -137,6 +138,20 @@
         "spectraVersion": "Spectra version",
         "apertureVersion": "Aperture version"
       }
+    },
+    "system": {
+      "title": "System settings",
+      "description": "Gateway configuration keys and their current values.",
+      "adminOnly": "Only administrators can view and change system settings.",
+      "empty": "No settings available.",
+      "error": "Failed to load settings.",
+      "edit": "Edit setting",
+      "value": "Value (JSON)",
+      "invalidJson": "The text is not valid JSON.",
+      "rejectedValue": "The gateway rejected this value.",
+      "missingKey": "This setting key no longer exists.",
+      "saved": "Setting saved.",
+      "saveFailed": "Failed to save the setting."
     }
   },
   "developer": {

--- a/modules/aperture/runtime/client.ts
+++ b/modules/aperture/runtime/client.ts
@@ -40,6 +40,7 @@ import type {
   RawLogSpanDetail,
   RawTask,
   RawTaskSchedule,
+  Setting,
   SetupBody,
   SetupStatus,
   StringPage,
@@ -48,6 +49,7 @@ import type {
   TaskPage,
   TaskSchedule,
   TaskSchedulePage,
+  UpdateSettingBody,
   UpdateTaskScheduleBody,
   User,
   UserPage,
@@ -236,6 +238,9 @@ export const apertureApi = {
   listUsers: async (params?: ListUsersParams): Promise<UserPage> =>
     unwrap(await client.GET("/api/v1/users", { params: { query: params } })),
 
+  getUser: async (id: string): Promise<User> =>
+    unwrap(await client.GET("/api/v1/users/{id}", { params: { path: { id } } })),
+
   createUser: async (body: CreateUserBody): Promise<User> =>
     unwrap(await client.POST("/api/v1/users", { body })),
 
@@ -292,6 +297,14 @@ export const apertureApi = {
   deleteTaskSchedule: async (id: string): Promise<void> => {
     unwrapVoid(await client.DELETE("/api/v1/task-schedules/{id}", { params: { path: { id } } }));
   },
+
+  listSettings: async (): Promise<Setting[]> => unwrap(await client.GET("/api/v1/settings")),
+
+  getSetting: async (key: string): Promise<Setting> =>
+    unwrap(await client.GET("/api/v1/settings/{key}", { params: { path: { key } } })),
+
+  updateSetting: async (key: string, body: UpdateSettingBody): Promise<Setting> =>
+    unwrap(await client.PUT("/api/v1/settings/{key}", { params: { path: { key } }, body })),
 
   listArtifacts: async (params?: ListArtifactsParams): Promise<ArtifactSummaryPage> => {
     const data = unwrap(await client.GET("/api/v1/artifacts", { params: { query: params } }));

--- a/modules/aperture/runtime/types.ts
+++ b/modules/aperture/runtime/types.ts
@@ -66,6 +66,7 @@ export type LoginResponse = Schemas["LoginResponse"];
 export type User = Schemas["UserResponse"];
 export type ApiKey = Schemas["ApiKeyResponse"];
 export type CreatedApiKey = Schemas["CreateApiKeyResponse"];
+export type Setting = Schemas["SettingResponse"];
 
 export type TaskStatus = Schemas["TaskStatusResponse"];
 export type TaskStatusParam = Schemas["TaskStatusParam"];
@@ -106,3 +107,4 @@ export type CreateApiKeyBody = Schemas["CreateApiKeyRequest"];
 export type CreateTaskBody = Schemas["CreateTaskInput"];
 export type CreateTaskScheduleBody = Schemas["CreateTaskScheduleRequest"];
 export type UpdateTaskScheduleBody = Schemas["UpdateTaskScheduleRequest"];
+export type UpdateSettingBody = Schemas["UpdateSettingRequest"];


### PR DESCRIPTION
Admin-only view of gateway setting keys with their current values and
a JSON editor for changes: invalid JSON is caught client-side, and the
gateway's 400 (rejected value) and 404 (missing key) responses surface
inline in the editor. Also wires the remaining getUser client method,
which completes coverage of the aperture API surface.