### PR TITLE
feat: schema-driven system settings

### DIFF
--- a/app/components/SchemaField.vue
+++ b/app/components/SchemaField.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { resolveRef, type JsonSchemaLike } from "~/utils/schemaDisplay";
+
+/**
+ * Leaf widget for a schema property: enum select, boolean checkbox, number
+ * input, or text input. Exposes the plain value; number inputs keep the
+ * string placeholder convention of the form state.
+ */
+const props = withDefaults(
+  defineProps<{
+    schema?: JsonSchemaLike;
+    doc?: JsonSchemaLike;
+  }>(),
+  { schema: undefined, doc: undefined },
+);
+
+const model = defineModel<FormValue>({ required: true });
+
+const resolved = computed(() =>
+  props.schema ? resolveRef(props.schema, props.doc ?? props.schema) : undefined,
+);
+
+const enumValues = computed<string[] | undefined>(() => {
+  if (!resolved.value?.enum?.length) return undefined;
+  return resolved.value.enum.filter((v): v is string => typeof v === "string");
+});
+
+const isBoolean = computed(() => resolved.value?.type === "boolean");
+const isNumber = computed(() => {
+  const t = resolved.value?.type;
+  return t === "number" || t === "integer";
+});
+
+function setText(v: string | number | null | undefined) {
+  if (typeof v === "number") {
+    model.value = String(v);
+    return;
+  }
+  model.value = v ?? "";
+}
+</script>
+
+<template>
+  <USelectMenu
+    v-if="enumValues"
+    :model-value="String(model ?? '')"
+    :items="enumValues"
+    class="w-full"
+    @update:model-value="(v) => (model = typeof v === 'string' ? v : '')"
+  />
+  <UCheckbox
+    v-else-if="isBoolean"
+    :model-value="model === true"
+    @update:model-value="(v) => (model = v === true)"
+  />
+  <UInput
+    v-else-if="isNumber"
+    :model-value="String(model ?? '')"
+    type="number"
+    class="w-full"
+    @update:model-value="setText"
+  />
+  <UInput v-else :model-value="String(model ?? '')" class="w-full" @update:model-value="setText" />
+</template>

--- a/app/components/SchemaForm.vue
+++ b/app/components/SchemaForm.vue
@@ -228,11 +228,14 @@ function setArrayItem(key: string, index: number, value: string) {
                 :name-prefix="`${field.path}.${i}`"
                 :depth="depth + 1"
               />
-              <UInput
+              <SchemaField
                 v-else
-                :model-value="String(asArray(field.key)[i] ?? '')"
-                class="w-full"
-                @update:model-value="(v) => setArrayItem(field.key, i, v)"
+                :model-value="asArray(field.key)[i] ?? ''"
+                :schema="field.schema?.items"
+                :doc="rootDoc"
+                @update:model-value="
+                  (v) => setArrayItem(field.key, i, typeof v === 'string' ? v : String(v ?? ''))
+                "
               />
             </div>
             <UButton
@@ -256,29 +259,10 @@ function setArrayItem(key: string, index: number, value: string) {
       </UFormField>
 
       <UFormField v-else :label="field.label" :description="field.description" :name="field.path">
-        <USelectMenu
-          v-if="field.kind === 'enum'"
-          :model-value="String(state[field.key] ?? '')"
-          :items="enumValues(field.schema)!"
-          class="w-full"
-          @update:model-value="(v) => setLeaf(field.key, typeof v === 'string' ? v : '')"
-        />
-        <UCheckbox
-          v-else-if="field.kind === 'boolean'"
-          :model-value="state[field.key] === true"
-          @update:model-value="(v) => setLeaf(field.key, v === true)"
-        />
-        <UInput
-          v-else-if="field.kind === 'number'"
-          :model-value="String(state[field.key] ?? '')"
-          type="number"
-          class="w-full"
-          @update:model-value="(v) => setLeaf(field.key, typeof v === 'number' ? String(v) : v)"
-        />
-        <UInput
-          v-else
-          :model-value="String(state[field.key] ?? '')"
-          class="w-full"
+        <SchemaField
+          :model-value="state[field.key] ?? ''"
+          :schema="field.schema"
+          :doc="rootDoc"
           @update:model-value="(v) => setLeaf(field.key, v)"
         />
       </UFormField>

--- a/app/composables/useSettingDefinitions.ts
+++ b/app/composables/useSettingDefinitions.ts
@@ -1,0 +1,34 @@
+import type {
+  ListSettingDefinitionsParams,
+  SettingDefinition,
+  SettingDefinitionSummary,
+} from "~~/modules/aperture/runtime/types";
+
+/** Paginated setting definition summaries. */
+export function useSettingDefinitionSummaries() {
+  return useInfiniteList<SettingDefinitionSummary, ListSettingDefinitionsParams>((query) =>
+    apertureApi.listSettingDefinitions(query),
+  );
+}
+
+/**
+ * Full setting definitions (with value schemas), fetched per key and cached
+ * app-wide. Failed fetches are not cached so a retry can succeed.
+ */
+export function useSettingDefinitionCache() {
+  const cache = useState<Map<string, SettingDefinition>>("setting-definitions", () => new Map());
+
+  async function getDefinition(key: string): Promise<SettingDefinition | undefined> {
+    const cached = cache.value.get(key);
+    if (cached) return cached;
+    try {
+      const definition = await apertureApi.getSettingDefinition(key);
+      cache.value.set(key, definition);
+      return definition;
+    } catch {
+      return undefined;
+    }
+  }
+
+  return { getDefinition };
+}

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -39,6 +39,11 @@ const links = computed(
                 icon: "i-lucide-users",
                 to: localePath("/settings/users"),
               },
+              {
+                label: t("settings.nav.system"),
+                icon: "i-lucide-server",
+                to: localePath("/settings/system"),
+              },
             ]
           : []),
       ],

--- a/app/pages/settings/system.vue
+++ b/app/pages/settings/system.vue
@@ -1,5 +1,18 @@
 <script setup lang="ts">
+import * as z from "zod/v4/mini";
 import type { Setting } from "~~/modules/aperture/runtime/types";
+import type { JsonSchemaLike } from "~/utils/schemaDisplay";
+import {
+  buildFormState,
+  buildZodSchema,
+  cleanFormState,
+  mergeFormState,
+  type FormState,
+} from "~/utils/schemaForm";
+import {
+  useSettingDefinitionCache,
+  useSettingDefinitionSummaries,
+} from "~/composables/useSettingDefinitions";
 
 const { t } = useI18n();
 const toast = useToast();
@@ -11,38 +24,99 @@ const { data, pending, error, refresh } = await useAsyncData<Setting[]>(
   { server: false },
 );
 
-function valuePreview(value: unknown): string {
-  return JSON.stringify(value) ?? "null";
+useSettingDefinitionSummaries();
+const { getDefinition } = useSettingDefinitionCache();
+
+const schemas = ref<Map<string, JsonSchemaLike | undefined>>(new Map());
+
+function schemaFor(key: string): JsonSchemaLike | undefined {
+  return schemas.value.get(key);
 }
 
-// Edit modal with a JSON editor; values are arbitrary JSON, so the text is
-// parsed before sending and the server's 400 is surfaced inline.
+async function loadSchema(key: string) {
+  if (schemas.value.has(key)) return;
+  schemas.value.set(key, undefined);
+  const definition = await getDefinition(key);
+  const schema = definition?.value_schema;
+  schemas.value.set(
+    key,
+    typeof schema === "object" && schema !== null ? (schema as JsonSchemaLike) : undefined,
+  );
+}
+
+watch(
+  () => data.value?.map((s) => s.key) ?? [],
+  (keys) => {
+    for (const key of keys) void loadSchema(key);
+  },
+  { immediate: true },
+);
+
+// A scalar schema root (string, number, boolean) renders one field instead
+// of an object form.
+function isObjectRoot(schema: JsonSchemaLike | undefined): boolean {
+  if (!schema) return false;
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  return type === "object" || !!schema.properties || !!schema.oneOf;
+}
+
+// Edit modal: schema-driven when a definition exists, raw JSON otherwise.
 
 const editOpen = ref(false);
+const editRaw = ref("");
 const editKey = ref("");
-const editText = ref("");
+const editSchema = ref<JsonSchemaLike | undefined>(undefined);
+const editState = ref<FormState>({});
+const editScalar = ref<string | number | boolean>("");
 const editError = ref<string | null>(null);
 const saving = ref(false);
 
+const editZodSchema = computed(() =>
+  editSchema.value && isObjectRoot(editSchema.value) ? buildZodSchema(editSchema.value) : z.any(),
+);
+
 function openEdit(setting: Setting) {
+  const schema = schemaFor(setting.key);
   editKey.value = setting.key;
-  editText.value = JSON.stringify(setting.value, null, 2) ?? "null";
+  editSchema.value = schema;
   editError.value = null;
+  if (schema && isObjectRoot(schema)) {
+    editState.value = mergeFormState(buildFormState(schema), setting.value);
+  } else if (schema) {
+    const v = setting.value;
+    editScalar.value =
+      typeof v === "string" || typeof v === "number" || typeof v === "boolean" ? v : "";
+  } else {
+    editRaw.value = JSON.stringify(setting.value, null, 2) ?? "null";
+  }
   editOpen.value = true;
 }
 
 async function onSave() {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(editText.value);
-  } catch {
-    editError.value = t("settings.system.invalidJson");
-    return;
+  let value: unknown;
+  if (editSchema.value && isObjectRoot(editSchema.value)) {
+    value = cleanFormState(editState.value, editSchema.value);
+  } else if (editSchema.value) {
+    value = editScalar.value;
+    const type = Array.isArray(editSchema.value.type)
+      ? editSchema.value.type[0]
+      : editSchema.value.type;
+    if ((type === "number" || type === "integer") && typeof value === "string" && value !== "") {
+      value = Number(value);
+    }
+  } else {
+    // No definition: fall back to raw JSON.
+    try {
+      value = JSON.parse(editRaw.value);
+    } catch {
+      editError.value = t("settings.system.invalidJson");
+      return;
+    }
   }
   editError.value = null;
   saving.value = true;
   try {
-    await apertureApi.updateSetting(editKey.value, { value: parsed });
+    await apertureApi.updateSetting(editKey.value, { value });
     editOpen.value = false;
     toast.add({ title: t("settings.system.saved"), color: "success" });
     await refresh();
@@ -85,25 +159,20 @@ async function onSave() {
     >
       <div class="flex flex-col gap-2">
         <UPageCard v-for="setting in data" :key="setting.key" variant="subtle">
-          <div class="flex sm:items-center justify-between gap-3">
-            <div class="flex flex-col min-w-0">
+          <div class="flex flex-col gap-2">
+            <div class="flex sm:items-center justify-between gap-3">
               <span class="font-mono text-sm truncate">{{ setting.key }}</span>
-              <span
-                class="text-muted text-xs font-mono truncate"
-                :title="valuePreview(setting.value)"
-              >
-                {{ valuePreview(setting.value) }}
-              </span>
+              <UButton
+                v-if="isAdmin"
+                icon="i-lucide-pencil"
+                color="neutral"
+                variant="ghost"
+                size="xs"
+                :aria-label="$t('settings.system.edit')"
+                @click="openEdit(setting)"
+              />
             </div>
-            <UButton
-              v-if="isAdmin"
-              icon="i-lucide-pencil"
-              color="neutral"
-              variant="ghost"
-              size="xs"
-              :aria-label="$t('settings.system.edit')"
-              @click="openEdit(setting)"
-            />
+            <SchemaValue :value="setting.value" :schema="schemaFor(setting.key)" />
           </div>
         </UPageCard>
       </div>
@@ -111,26 +180,44 @@ async function onSave() {
 
     <UModal v-model:open="editOpen" :title="editKey">
       <template #body>
-        <div class="flex flex-col gap-4">
-          <UFormField
-            :label="$t('settings.system.value')"
-            :error="editError ?? undefined"
-            name="value"
-          >
-            <UTextarea
-              v-model="editText"
-              :rows="8"
-              class="w-full font-mono text-xs"
-              autocomplete="off"
-              spellcheck="false"
-            />
+        <UForm
+          :schema="editZodSchema"
+          :state="editState"
+          class="flex flex-col gap-4"
+          @submit="onSave()"
+        >
+          <SchemaForm
+            v-if="editSchema && isObjectRoot(editSchema)"
+            v-model:state="editState"
+            :schema="editSchema"
+          />
+          <UFormField v-else-if="editSchema" :label="$t('settings.system.value')">
+            <SchemaField v-model="editScalar" :schema="editSchema" />
           </UFormField>
+          <template v-else>
+            <p class="text-muted text-xs">{{ $t("settings.system.fallbackJson") }}</p>
+            <UFormField
+              :label="$t('settings.system.value')"
+              :error="editError ?? undefined"
+              name="raw"
+            >
+              <UTextarea
+                v-model="editRaw"
+                :rows="8"
+                class="w-full font-mono text-xs"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </UFormField>
+          </template>
+
+          <p v-if="editError && editSchema" class="text-error text-xs">{{ editError }}</p>
 
           <div class="flex justify-end gap-2">
             <UButton variant="ghost" :label="$t('common.cancel')" @click="editOpen = false" />
-            <UButton :loading="saving" :label="$t('common.save')" @click="onSave()" />
+            <UButton type="submit" :loading="saving" :label="$t('common.save')" />
           </div>
-        </div>
+        </UForm>
       </template>
     </UModal>
   </div>

--- a/app/pages/settings/system.vue
+++ b/app/pages/settings/system.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import type { Setting } from "~~/modules/aperture/runtime/types";
+
+const { t } = useI18n();
+const toast = useToast();
+const { isAdmin } = useAuth();
+
+const { data, pending, error, refresh } = await useAsyncData<Setting[]>(
+  "settings",
+  () => apertureApi.listSettings(),
+  { server: false },
+);
+
+function valuePreview(value: unknown): string {
+  return JSON.stringify(value) ?? "null";
+}
+
+// Edit modal with a JSON editor; values are arbitrary JSON, so the text is
+// parsed before sending and the server's 400 is surfaced inline.
+
+const editOpen = ref(false);
+const editKey = ref("");
+const editText = ref("");
+const editError = ref<string | null>(null);
+const saving = ref(false);
+
+function openEdit(setting: Setting) {
+  editKey.value = setting.key;
+  editText.value = JSON.stringify(setting.value, null, 2) ?? "null";
+  editError.value = null;
+  editOpen.value = true;
+}
+
+async function onSave() {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(editText.value);
+  } catch {
+    editError.value = t("settings.system.invalidJson");
+    return;
+  }
+  editError.value = null;
+  saving.value = true;
+  try {
+    await apertureApi.updateSetting(editKey.value, { value: parsed });
+    editOpen.value = false;
+    toast.add({ title: t("settings.system.saved"), color: "success" });
+    await refresh();
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 400) {
+      editError.value = t("settings.system.rejectedValue");
+    } else if (err instanceof ApiError && err.status === 404) {
+      editError.value = t("settings.system.missingKey");
+    } else {
+      toast.add({ title: t("settings.system.saveFailed"), color: "error" });
+    }
+  } finally {
+    saving.value = false;
+  }
+}
+</script>
+
+<template>
+  <div>
+    <UPageCard
+      :title="$t('settings.system.title')"
+      :description="$t('settings.system.description')"
+      variant="naked"
+      orientation="horizontal"
+      class="mb-4"
+    />
+
+    <p v-if="!isAdmin" class="text-muted text-sm mb-4">
+      {{ $t("settings.system.adminOnly") }}
+    </p>
+
+    <DataState
+      :pending="pending"
+      :error="error ? String(error) : null"
+      :empty="!data?.length"
+      :empty-text="$t('settings.system.empty')"
+      :error-text="$t('settings.system.error')"
+      :retry-text="$t('common.retry')"
+      @retry="refresh()"
+    >
+      <div class="flex flex-col gap-2">
+        <UPageCard v-for="setting in data" :key="setting.key" variant="subtle">
+          <div class="flex sm:items-center justify-between gap-3">
+            <div class="flex flex-col min-w-0">
+              <span class="font-mono text-sm truncate">{{ setting.key }}</span>
+              <span
+                class="text-muted text-xs font-mono truncate"
+                :title="valuePreview(setting.value)"
+              >
+                {{ valuePreview(setting.value) }}
+              </span>
+            </div>
+            <UButton
+              v-if="isAdmin"
+              icon="i-lucide-pencil"
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              :aria-label="$t('settings.system.edit')"
+              @click="openEdit(setting)"
+            />
+          </div>
+        </UPageCard>
+      </div>
+    </DataState>
+
+    <UModal v-model:open="editOpen" :title="editKey">
+      <template #body>
+        <div class="flex flex-col gap-4">
+          <UFormField
+            :label="$t('settings.system.value')"
+            :error="editError ?? undefined"
+            name="value"
+          >
+            <UTextarea
+              v-model="editText"
+              :rows="8"
+              class="w-full font-mono text-xs"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </UFormField>
+
+          <div class="flex justify-end gap-2">
+            <UButton variant="ghost" :label="$t('common.cancel')" @click="editOpen = false" />
+            <UButton :loading="saving" :label="$t('common.save')" @click="onSave()" />
+          </div>
+        </div>
+      </template>
+    </UModal>
+  </div>
+</template>

--- a/app/utils/schemaForm.ts
+++ b/app/utils/schemaForm.ts
@@ -98,8 +98,33 @@ export function buildFormState(schemaIn: JsonSchemaLike, doc?: JsonSchemaLike): 
   return state;
 }
 
-function isFormState(value: FormValue): value is FormState {
+function isFormState(value: FormValue | undefined): value is FormState {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Overlays a current value onto schema-seeded form state so editing starts
+ * from the stored value while keeping defaults for keys it omits.
+ */
+export function mergeFormState(seed: FormState, value: unknown): FormState {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return seed;
+  const out: FormState = { ...seed };
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    const formValue: FormValue | undefined =
+      typeof v === "string" || typeof v === "number" || typeof v === "boolean" || v === null
+        ? v
+        : Array.isArray(v)
+          ? (v as FormValue[])
+          : (v as FormState);
+    if (formValue === undefined) continue;
+    const seeded = out[k];
+    if (isFormState(seeded) && isFormState(formValue)) {
+      out[k] = mergeFormState(seeded, formValue);
+    } else {
+      out[k] = formValue;
+    }
+  }
+  return out;
 }
 
 /**

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,9 +1,24 @@
 import { expect, test } from "@playwright/test";
 
 const stubSettings = [
-  { key: "aperture.avatar.style", value: "constellation" },
   { key: "aperture.log.level", value: { min_level: "info", format: "json" } },
+  { key: "aperture.avatar.style", value: "constellation" },
+  { key: "mystery.key", value: { any: ["shape"] } },
 ];
+
+const stubDefinitions = {
+  "aperture.log.level": {
+    type: "object",
+    required: ["min_level", "format"],
+    properties: {
+      min_level: { type: "string", enum: ["trace", "debug", "info", "warn", "error"] },
+      format: { type: "string", enum: ["json", "text"] },
+    },
+  },
+  "aperture.avatar.style": { type: "string", enum: ["constellation", "identicon", "bottts"] },
+};
+
+const definitionSummaries = [{ key: "aperture.log.level" }, { key: "aperture.avatar.style" }];
 
 function stubSettingsApi(
   page: import("@playwright/test").Page,
@@ -12,7 +27,7 @@ function stubSettingsApi(
   return page.route("**/api/v1/**", async (route) => {
     const request = route.request();
     const url = new URL(request.url());
-    const pathname = url.pathname;
+    const pathname = decodeURIComponent(url.pathname);
 
     if (pathname === "/api/v1/auth/setup-status") {
       await route.fulfill({
@@ -35,6 +50,31 @@ function stubSettingsApi(
           roles: ["admin"],
           must_change_password: false,
         }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/setting-definitions") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: definitionSummaries, next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    const defMatch = pathname.match(/^\/api\/v1\/setting-definitions\/(.+)$/);
+    if (defMatch) {
+      const key = decodeURIComponent(defMatch[1]!);
+      const value_schema = stubDefinitions[key as keyof typeof stubDefinitions];
+      if (!value_schema) {
+        await route.fulfill({ status: 404 });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ key, value_schema }),
       });
       return;
     }
@@ -70,25 +110,73 @@ function stubSettingsApi(
   });
 }
 
-test("system settings list and JSON editor", async ({ page }) => {
+test("settings render schema-driven and edit through the form", async ({ page }) => {
   const captured = { puts: [] as { key: string; body: unknown }[] };
   await stubSettingsApi(page, captured);
 
   await page.goto("/en/settings/system", { waitUntil: "domcontentloaded" });
 
   await expect(page.getByText("System settings", { exact: true })).toBeVisible();
-  await expect(page.getByText("aperture.avatar.style", { exact: true })).toBeVisible();
-  await expect(page.getByText('"constellation"')).toBeVisible();
+  await expect(page.getByText("aperture.log.level", { exact: true })).toBeVisible();
 
-  // Open the editor for the object-valued setting.
-  await page
-    .locator("div")
-    .filter({ hasText: /^aperture\.log\.level/ })
-    .getByRole("button", { name: "Edit setting" })
-    .click();
+  // Schema-driven rendering: enum values become badges, fields get labels.
+  await expect(page.getByText("min_level:")).toBeVisible();
+  await expect(page.getByText("info").first()).toBeVisible();
+  await expect(page.getByText("format:")).toBeVisible();
+  await expect(page.getByText("json").first()).toBeVisible();
+
+  // Open the editor for the object setting: a schema-driven form appears.
+  await page.getByRole("button", { name: "Edit setting" }).nth(0).click();
 
   const dialog = page.getByRole("dialog");
   await expect(dialog).toBeVisible();
+
+  const selects = dialog.getByRole("button", { name: "Show popup" });
+  await selects.nth(0).click();
+  await page.getByRole("option", { name: "debug" }).click();
+
+  await dialog.getByRole("button", { name: "Save" }).click();
+
+  await expect.poll(() => captured.puts.length).toBe(1);
+  expect(captured.puts[0]).toEqual({
+    key: "aperture.log.level",
+    body: { value: { min_level: "debug", format: "json" } },
+  });
+});
+
+test("scalar settings edit through a single field", async ({ page }) => {
+  const captured = { puts: [] as { key: string; body: unknown }[] };
+  await stubSettingsApi(page, captured);
+
+  await page.goto("/en/settings/system", { waitUntil: "domcontentloaded" });
+
+  await page.getByRole("button", { name: "Edit setting" }).nth(1).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Show popup" }).click();
+  await page.getByRole("option", { name: "identicon" }).click();
+
+  await dialog.getByRole("button", { name: "Save" }).click();
+
+  await expect.poll(() => captured.puts.length).toBe(1);
+  expect(captured.puts[0]).toEqual({
+    key: "aperture.avatar.style",
+    body: { value: "identicon" },
+  });
+});
+
+test("keys without a definition fall back to raw JSON editing", async ({ page }) => {
+  const captured = { puts: [] as { key: string; body: unknown }[] };
+  await stubSettingsApi(page, captured);
+
+  await page.goto("/en/settings/system", { waitUntil: "domcontentloaded" });
+
+  await page.getByRole("button", { name: "Edit setting" }).nth(2).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText(/raw JSON/)).toBeVisible();
 
   // Invalid JSON is caught client-side and never sent.
   const editor = dialog.locator("textarea");
@@ -97,13 +185,12 @@ test("system settings list and JSON editor", async ({ page }) => {
   await expect(dialog.getByText("The text is not valid JSON.")).toBeVisible();
   expect(captured.puts).toHaveLength(0);
 
-  // A valid edit parses and PUTs the typed JSON.
-  await editor.fill('{"min_level":"debug","format":"json"}');
+  await editor.fill('{"any":["shape","more"]}');
   await dialog.getByRole("button", { name: "Save" }).click();
 
   await expect.poll(() => captured.puts.length).toBe(1);
   expect(captured.puts[0]).toEqual({
-    key: "aperture.log.level",
-    body: { value: { min_level: "debug", format: "json" } },
+    key: "mystery.key",
+    body: { value: { any: ["shape", "more"] } },
   });
 });

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+
+const stubSettings = [
+  { key: "aperture.avatar.style", value: "constellation" },
+  { key: "aperture.log.level", value: { min_level: "info", format: "json" } },
+];
+
+function stubSettingsApi(
+  page: import("@playwright/test").Page,
+  captured: { puts: { key: string; body: unknown }[] },
+) {
+  return page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const pathname = url.pathname;
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    const putMatch = pathname.match(/^\/api\/v1\/settings\/(.+)$/);
+    if (putMatch && request.method() === "PUT") {
+      captured.puts.push({ key: decodeURIComponent(putMatch[1]!), body: request.postDataJSON() });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          key: putMatch[1],
+          value: request.postDataJSON()?.value ?? null,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/settings") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(stubSettings),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+}
+
+test("system settings list and JSON editor", async ({ page }) => {
+  const captured = { puts: [] as { key: string; body: unknown }[] };
+  await stubSettingsApi(page, captured);
+
+  await page.goto("/en/settings/system", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByText("System settings", { exact: true })).toBeVisible();
+  await expect(page.getByText("aperture.avatar.style", { exact: true })).toBeVisible();
+  await expect(page.getByText('"constellation"')).toBeVisible();
+
+  // Open the editor for the object-valued setting.
+  await page
+    .locator("div")
+    .filter({ hasText: /^aperture\.log\.level/ })
+    .getByRole("button", { name: "Edit setting" })
+    .click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+
+  // Invalid JSON is caught client-side and never sent.
+  const editor = dialog.locator("textarea");
+  await editor.fill("{ not json");
+  await dialog.getByRole("button", { name: "Save" }).click();
+  await expect(dialog.getByText("The text is not valid JSON.")).toBeVisible();
+  expect(captured.puts).toHaveLength(0);
+
+  // A valid edit parses and PUTs the typed JSON.
+  await editor.fill('{"min_level":"debug","format":"json"}');
+  await dialog.getByRole("button", { name: "Save" }).click();
+
+  await expect.poll(() => captured.puts.length).toBe(1);
+  expect(captured.puts[0]).toEqual({
+    key: "aperture.log.level",
+    body: { value: { min_level: "debug", format: "json" } },
+  });
+});

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -112,7 +112,8 @@
       "about": "Info",
       "account": "Konto",
       "apiKeys": "API-Schlüssel",
-      "users": "Benutzer"
+      "users": "Benutzer",
+      "system": "System"
     },
     "sections": {
       "dashboard": {
@@ -137,6 +138,20 @@
         "spectraVersion": "Spectra-Version",
         "apertureVersion": "Aperture-Version"
       }
+    },
+    "system": {
+      "title": "Systemeinstellungen",
+      "description": "Konfigurationsschlüssel des Gateways und ihre aktuellen Werte.",
+      "adminOnly": "Nur Administratoren können Systemeinstellungen sehen und ändern.",
+      "empty": "Keine Einstellungen verfügbar.",
+      "error": "Einstellungen konnten nicht geladen werden.",
+      "edit": "Einstellung bearbeiten",
+      "value": "Wert (JSON)",
+      "invalidJson": "Der Text ist kein gültiges JSON.",
+      "rejectedValue": "Der Gateway hat diesen Wert abgelehnt.",
+      "missingKey": "Dieser Konfigurationsschlüssel existiert nicht mehr.",
+      "saved": "Einstellung gespeichert.",
+      "saveFailed": "Einstellung konnte nicht gespeichert werden."
     }
   },
   "developer": {

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -151,7 +151,8 @@
       "rejectedValue": "Der Gateway hat diesen Wert abgelehnt.",
       "missingKey": "Dieser Konfigurationsschlüssel existiert nicht mehr.",
       "saved": "Einstellung gespeichert.",
-      "saveFailed": "Einstellung konnte nicht gespeichert werden."
+      "saveFailed": "Einstellung konnte nicht gespeichert werden.",
+      "fallbackJson": "Für diesen Schlüssel gibt es kein Schema, JSON wird direkt bearbeitet."
     }
   },
   "developer": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -112,7 +112,8 @@
       "about": "About",
       "account": "Account",
       "apiKeys": "API keys",
-      "users": "Users"
+      "users": "Users",
+      "system": "System"
     },
     "sections": {
       "dashboard": {
@@ -137,6 +138,20 @@
         "spectraVersion": "Spectra version",
         "apertureVersion": "Aperture version"
       }
+    },
+    "system": {
+      "title": "System settings",
+      "description": "Gateway configuration keys and their current values.",
+      "adminOnly": "Only administrators can view and change system settings.",
+      "empty": "No settings available.",
+      "error": "Failed to load settings.",
+      "edit": "Edit setting",
+      "value": "Value (JSON)",
+      "invalidJson": "The text is not valid JSON.",
+      "rejectedValue": "The gateway rejected this value.",
+      "missingKey": "This setting key no longer exists.",
+      "saved": "Setting saved.",
+      "saveFailed": "Failed to save the setting."
     }
   },
   "developer": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -151,7 +151,8 @@
       "rejectedValue": "The gateway rejected this value.",
       "missingKey": "This setting key no longer exists.",
       "saved": "Setting saved.",
-      "saveFailed": "Failed to save the setting."
+      "saveFailed": "Failed to save the setting.",
+      "fallbackJson": "No schema is available for this key, editing raw JSON."
     }
   },
   "developer": {

--- a/modules/aperture/runtime/client.ts
+++ b/modules/aperture/runtime/client.ts
@@ -42,6 +42,7 @@ import type {
   RawLogSpanDetail,
   RawTask,
   RawTaskSchedule,
+  Setting,
   SettingDefinition,
   SettingDefinitionPage,
   SetupBody,
@@ -53,6 +54,7 @@ import type {
   TaskPage,
   TaskSchedule,
   TaskSchedulePage,
+  UpdateSettingBody,
   UpdateTaskScheduleBody,
   User,
   UserPage,
@@ -241,6 +243,9 @@ export const apertureApi = {
   listUsers: async (params?: ListUsersParams): Promise<UserPage> =>
     unwrap(await client.GET("/api/v1/users", { params: { query: params } })),
 
+  getUser: async (id: string): Promise<User> =>
+    unwrap(await client.GET("/api/v1/users/{id}", { params: { path: { id } } })),
+
   createUser: async (body: CreateUserBody): Promise<User> =>
     unwrap(await client.POST("/api/v1/users", { body })),
 
@@ -308,6 +313,14 @@ export const apertureApi = {
   deleteTaskSchedule: async (id: string): Promise<void> => {
     unwrapVoid(await client.DELETE("/api/v1/task-schedules/{id}", { params: { path: { id } } }));
   },
+
+  listSettings: async (): Promise<Setting[]> => unwrap(await client.GET("/api/v1/settings")),
+
+  getSetting: async (key: string): Promise<Setting> =>
+    unwrap(await client.GET("/api/v1/settings/{key}", { params: { path: { key } } })),
+
+  updateSetting: async (key: string, body: UpdateSettingBody): Promise<Setting> =>
+    unwrap(await client.PUT("/api/v1/settings/{key}", { params: { path: { key } }, body })),
 
   listArtifacts: async (params?: ListArtifactsParams): Promise<ArtifactSummaryPage> => {
     const data = unwrap(await client.GET("/api/v1/artifacts", { params: { query: params } }));

--- a/modules/aperture/runtime/types.ts
+++ b/modules/aperture/runtime/types.ts
@@ -72,6 +72,7 @@ export type LoginResponse = Schemas["LoginResponse"];
 export type User = Schemas["UserResponse"];
 export type ApiKey = Schemas["ApiKeyResponse"];
 export type CreatedApiKey = Schemas["CreateApiKeyResponse"];
+export type Setting = Schemas["SettingResponse"];
 
 export type TaskStatus = Schemas["TaskStatusResponse"];
 export type TaskStatusParam = Schemas["TaskStatusParam"];
@@ -117,3 +118,4 @@ export type CreateApiKeyBody = Schemas["CreateApiKeyRequest"];
 export type CreateTaskBody = Schemas["CreateTaskRequest"];
 export type CreateTaskScheduleBody = Schemas["CreateTaskScheduleRequest"];
 export type UpdateTaskScheduleBody = Schemas["UpdateTaskScheduleRequest"];
+export type UpdateSettingBody = Schemas["UpdateSettingRequest"];

--- a/test/schemaForm.test.ts
+++ b/test/schemaForm.test.ts
@@ -6,7 +6,9 @@ import {
   buildZodSchema,
   cleanFormState,
   defaultOneOfBranch,
+  mergeFormState,
   oneOfBranchTag,
+  type FormState,
 } from "~/utils/schemaForm";
 
 const doc: JsonSchemaLike = {
@@ -151,5 +153,29 @@ describe("buildZodSchema", () => {
 
     const badTag = { key: "k", source: { reference: "r", media_type: "m", type: "docker" } };
     expect(z.safeParse(schema, badTag).success).toBe(false);
+  });
+});
+
+describe("mergeFormState", () => {
+  it("overlays stored values onto schema-seeded defaults", () => {
+    const seed = buildFormState(downloadInput);
+    const merged = mergeFormState(seed, { key: "firmware" });
+    expect(merged.key).toBe("firmware");
+    expect(merged.source).toEqual({ reference: "", media_type: "", type: "oci" });
+  });
+
+  it("merges nested objects and keeps unknown keys", () => {
+    const merged = mergeFormState(
+      { source: { reference: "", media_type: "", type: "oci" }, extra: "" },
+      { source: { reference: "ghcr.io/org/img:1" }, unknown: 3 },
+    );
+    expect(merged.source).toEqual({ reference: "ghcr.io/org/img:1", media_type: "", type: "oci" });
+    expect(merged.unknown).toBe(3);
+  });
+
+  it("returns the seed for non-object values", () => {
+    const seed: FormState = { key: "spectra" };
+    expect(mergeFormState(seed, null)).toBe(seed);
+    expect(mergeFormState(seed, "nope")).toBe(seed);
   });
 });


### PR DESCRIPTION
Setting values render through SchemaValue against their definition's
JSON Schema, and the editor is schema-driven too: object roots get a
SchemaForm seeded from the stored value (new mergeFormState), scalar
roots a single SchemaField extracted from SchemaForm's leaf widgets,
and keys without a definition fall back to the raw JSON editor.
Schemas come from the setting-definitions endpoints at runtime.

Supersedes #262 (same value endpoints, page rebuilt on the schema
machinery). Stacked on #263.