### PR TITLE
fix: schema form coercion, validation, and oneOf handling

### DIFF
--- a/app/components/SchemaField.vue
+++ b/app/components/SchemaField.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { resolveRef, type JsonSchemaLike } from "~/utils/schemaDisplay";
+import { resolveRef, stringEnums, typeOf, type JsonSchemaLike } from "~/utils/schemaCore";
 
 /**
  * Leaf widget for a schema property: enum select, boolean checkbox, number
@@ -20,15 +20,22 @@ const resolved = computed(() =>
   props.schema ? resolveRef(props.schema, props.doc ?? props.schema) : undefined,
 );
 
-const enumValues = computed<string[] | undefined>(() => {
-  if (!resolved.value?.enum?.length) return undefined;
-  return resolved.value.enum.filter((v): v is string => typeof v === "string");
+const enumValues = computed<string[] | undefined>(() =>
+  resolved.value ? stringEnums(resolved.value) : undefined,
+);
+
+const isBoolean = computed(() => typeOf(resolved.value) === "boolean");
+const isNumber = computed(() => {
+  const t = typeOf(resolved.value);
+  return t === "number" || t === "integer";
 });
 
-const isBoolean = computed(() => resolved.value?.type === "boolean");
-const isNumber = computed(() => {
-  const t = resolved.value?.type;
-  return t === "number" || t === "integer";
+const numberStep = computed<number | undefined>(() => {
+  const multiple = resolved.value?.multipleOf;
+  if (typeof multiple === "number" && multiple > 0 && Number.isFinite(multiple)) {
+    return multiple;
+  }
+  return typeOf(resolved.value) === "integer" ? 1 : undefined;
 });
 
 function setText(v: string | number | null | undefined) {
@@ -57,8 +64,17 @@ function setText(v: string | number | null | undefined) {
     v-else-if="isNumber"
     :model-value="String(model ?? '')"
     type="number"
+    :min="resolved?.minimum"
+    :max="resolved?.maximum"
+    :step="numberStep"
     class="w-full"
     @update:model-value="setText"
   />
-  <UInput v-else :model-value="String(model ?? '')" class="w-full" @update:model-value="setText" />
+  <UInput
+    v-else
+    :model-value="String(model ?? '')"
+    :maxlength="resolved?.maxLength"
+    class="w-full"
+    @update:model-value="setText"
+  />
 </template>

--- a/app/components/SchemaForm.vue
+++ b/app/components/SchemaForm.vue
@@ -1,6 +1,18 @@
 <script setup lang="ts">
-import { resolveRef, type JsonSchemaLike } from "~/utils/schemaDisplay";
-import { buildFormState, oneOfBranchTag, type FormState, type FormValue } from "~/utils/schemaForm";
+import {
+  isRecord,
+  oneOfBranchTag,
+  resolveRef,
+  stringEnums,
+  type JsonSchemaLike,
+  typeOf,
+} from "~/utils/schemaCore";
+import {
+  buildFormState,
+  defaultOneOfBranch,
+  type FormState,
+  type FormValue,
+} from "~/utils/schemaForm";
 
 const props = withDefaults(
   defineProps<{
@@ -19,18 +31,6 @@ const state = defineModel<FormState>("state", { required: true });
 const rootDoc = computed(() => props.doc ?? props.schema);
 
 const MAX_DEPTH = 6;
-
-function typeOf(schema: JsonSchemaLike | undefined): string | undefined {
-  if (!schema) return undefined;
-  if (typeof schema.type === "string") return schema.type;
-  if (Array.isArray(schema.type)) return schema.type.find((t) => t !== "null");
-  return undefined;
-}
-
-function enumValues(schema: JsonSchemaLike | undefined): string[] | undefined {
-  if (!schema?.enum?.length) return undefined;
-  return schema.enum.filter((v): v is string => typeof v === "string");
-}
 
 interface Field {
   key: string;
@@ -64,12 +64,39 @@ function classify(field: Omit<Field, "kind" | "branches">): Pick<Field, "kind" |
     case "integer":
       return { kind: "number" };
     default:
-      return enumValues(schema)?.length ? { kind: "enum" } : { kind: "text" };
+      return stringEnums(schema ?? {})?.length ? { kind: "enum" } : { kind: "text" };
   }
 }
 
+const rootBranches = computed<{ label: string; branch: JsonSchemaLike }[] | undefined>(() => {
+  const resolved = resolveRef(props.schema, rootDoc.value);
+  if (!resolved?.oneOf?.length) return undefined;
+  if (defaultOneOfBranch(resolved)) return undefined; // single branch unwraps silently
+  return resolved.oneOf.map((branch) => ({
+    label: branch.description ?? String(oneOfBranchTag(branch)?.[1] ?? branch.title ?? "option"),
+    branch,
+  }));
+});
+
+const rootChoice = ref<string | undefined>(undefined);
+const activeRootBranch = computed(
+  () => rootBranches.value?.find((b) => b.label === rootChoice.value) ?? rootBranches.value?.[0],
+);
+
+// A root oneOf with a single resolvable branch renders that branch directly.
+function effectiveSchema(): JsonSchemaLike | undefined {
+  if (rootBranches.value) {
+    const branch = activeRootBranch.value?.branch;
+    return branch ? (resolveRef(branch, rootDoc.value) ?? branch) : undefined;
+  }
+  const resolved = resolveRef(props.schema, rootDoc.value);
+  if (!resolved?.oneOf?.length) return resolved;
+  const branch = defaultOneOfBranch(resolved)?.branch;
+  return branch ? (resolveRef(branch, rootDoc.value) ?? branch) : resolved;
+}
+
 const fields = computed<Field[]>(() => {
-  const schema = resolveRef(props.schema, rootDoc.value);
+  const schema = effectiveSchema();
   if (!schema?.properties) return [];
   return Object.entries(schema.properties)
     .map(([key, prop]) => {
@@ -109,28 +136,27 @@ function selectedBranch(field: Field): JsonSchemaLike | undefined {
   return field.branches.find((b) => b.label === label)?.branch;
 }
 
-function selectBranch(field: Field, label: string | undefined) {
-  branchChoices.set(field.key, label ?? "");
-  const branch = field.branches?.find((b) => b.label === label)?.branch;
-  if (!branch) return;
+function seedBranchState(field: Field, branch: JsonSchemaLike) {
   const nested = buildFormState(branch, rootDoc.value);
   const tag = oneOfBranchTag(branch);
-  if (tag) nested[tag[0]] = tag[1];
+  if (tag) nested[tag[0] as string] = tag[1] as FormValue;
   state.value[field.key] = nested;
 }
 
-function isRecord(value: FormValue | undefined): value is FormState {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+function selectBranch(field: Field, label: string | undefined) {
+  branchChoices.set(field.key, label ?? "");
+  const branch = field.branches?.find((b) => b.label === label)?.branch;
+  if (branch) seedBranchState(field, branch);
 }
 
 function stateAt(key: string): FormState | undefined {
   const v = state.value[key];
-  return isRecord(v) ? v : undefined;
+  return isRecord(v) ? (v as FormState) : undefined;
 }
 
 function itemAt(key: string, index: number): FormState | undefined {
   const v = asArray(key)[index];
-  return isRecord(v) ? v : undefined;
+  return isRecord(v) ? (v as FormState) : undefined;
 }
 
 function asArray(key: string): FormValue[] {
@@ -159,10 +185,50 @@ function setArrayItem(key: string, index: number, value: string) {
   arr[index] = value;
   state.value[key] = arr;
 }
+
+function selectRootBranch(label: string | undefined) {
+  rootChoice.value = label;
+  const branch = rootBranches.value?.find((b) => b.label === label)?.branch;
+  if (!branch) return;
+  const nested = buildFormState(branch, rootDoc.value);
+  const tag = oneOfBranchTag(branch);
+  if (tag) nested[tag[0] as string] = tag[1] as FormValue;
+  state.value = nested;
+}
+
+watch(
+  rootBranches,
+  (branches) => {
+    if (!branches?.length) return;
+    if (Object.keys(state.value).length > 0) return;
+    selectRootBranch(branches[0]!.label);
+  },
+  { immediate: true },
+);
+
+watch(
+  () => fields.value.filter((f) => f.kind === "branch-select"),
+  (branchFields) => {
+    for (const field of branchFields) {
+      if (stateAt(field.key) !== undefined) continue;
+      const branch = field.branches?.[0]?.branch;
+      if (branch) seedBranchState(field, branch);
+    }
+  },
+  { immediate: true },
+);
 </script>
 
 <template>
   <div class="flex flex-col gap-4">
+    <UFormField v-if="rootBranches" :label="activeRootBranch?.label">
+      <USelectMenu
+        :model-value="activeRootBranch?.label"
+        :items="rootBranches.map((b) => b.label)"
+        class="w-full"
+        @update:model-value="(v) => selectRootBranch(typeof v === 'string' ? v : undefined)"
+      />
+    </UFormField>
     <template v-for="field in fields" :key="field.key">
       <UFormField
         v-if="field.kind === 'branch-select'"

--- a/app/components/SchemaValue.vue
+++ b/app/components/SchemaValue.vue
@@ -1,11 +1,6 @@
 <script setup lang="ts">
-import {
-  pickOneOfBranch,
-  resolveRef,
-  schemaEntries,
-  type JsonSchemaLike,
-  type SchemaRow,
-} from "~/utils/schemaDisplay";
+import { pickOneOfBranch, schemaEntries } from "~/utils/schemaDisplay";
+import { resolveRef, type JsonSchemaLike } from "~/utils/schemaCore";
 import { formatValue } from "~/utils/logFields";
 
 const props = withDefaults(
@@ -45,8 +40,6 @@ const rows = computed(() => {
 const isObject = (v: unknown): boolean => typeof v === "object" && v !== null && !Array.isArray(v);
 
 const isArray = Array.isArray;
-
-const rowSchema = (row: SchemaRow): JsonSchemaLike | undefined => row.schema;
 
 function scalarType(schema: JsonSchemaLike | undefined): "bool" | "enum" | "text" {
   if (schema?.type === "boolean") return "bool";
@@ -96,7 +89,7 @@ const rawJson = computed(() => {
         <SchemaValue
           v-if="isObject(row.value) || isArray(row.value)"
           :value="row.value"
-          :schema="rowSchema(row)"
+          :schema="row.schema"
           :doc="rootDoc"
           :depth="depth + 1"
           :empty-text="emptyText"

--- a/app/utils/schemaCore.ts
+++ b/app/utils/schemaCore.ts
@@ -1,0 +1,73 @@
+export interface JsonSchemaLike {
+  $ref?: string;
+  $defs?: Record<string, JsonSchemaLike>;
+  type?: string | string[];
+  title?: string;
+  description?: string;
+  enum?: unknown[];
+  oneOf?: JsonSchemaLike[];
+  properties?: Record<string, JsonSchemaLike>;
+  items?: JsonSchemaLike;
+  required?: string[];
+  format?: string;
+  default?: unknown;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  minimum?: number;
+  maximum?: number;
+  exclusiveMinimum?: number;
+  exclusiveMaximum?: number;
+  minItems?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Resolves `$ref` pointers against the standalone schema document they came
+ * from. Definitions endpoints serve draft 2020-12 documents with dependencies
+ * under `$defs`, so `#/$defs/Name` is the shape in play. Sibling keywords next
+ * to `$ref` (e.g. a `description`) win over the target. Returns undefined for
+ * pointers the document does not contain.
+ */
+export function resolveRef(
+  schema: JsonSchemaLike,
+  doc?: JsonSchemaLike,
+): JsonSchemaLike | undefined {
+  if (!schema.$ref) return schema;
+  const prefix = "#/$defs/";
+  if (!schema.$ref.startsWith(prefix) || !doc?.$defs) return undefined;
+  const name = schema.$ref.slice(prefix.length);
+  const target = doc.$defs[name];
+  if (!target) return undefined;
+  const { $ref: _, ...siblings } = schema;
+  return { ...resolveRef(target, doc), ...siblings };
+}
+
+export function typeOf(schema: JsonSchemaLike | undefined): string | undefined {
+  if (!schema) return undefined;
+  if (typeof schema.type === "string") return schema.type;
+  if (Array.isArray(schema.type)) return schema.type.find((t) => t !== "null");
+  return undefined;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The single-value enum constant a `oneOf` branch carries under `type`,
+ * `kind`, or `key`, which discriminates it from sibling branches.
+ */
+export function oneOfBranchTag(branch: JsonSchemaLike): [string, unknown] | undefined {
+  for (const key of ["type", "kind", "key"]) {
+    const prop = branch.properties?.[key];
+    if (prop?.enum?.length === 1) return [key, prop.enum[0]];
+  }
+  return undefined;
+}
+
+export function stringEnums(schema: JsonSchemaLike): string[] | undefined {
+  if (!schema.enum?.length) return undefined;
+  const values = schema.enum.filter((v): v is string => typeof v === "string");
+  return values.length === 0 ? undefined : values;
+}

--- a/app/utils/schemaDisplay.ts
+++ b/app/utils/schemaDisplay.ts
@@ -1,39 +1,6 @@
-export interface JsonSchemaLike {
-  $ref?: string;
-  $defs?: Record<string, JsonSchemaLike>;
-  type?: string | string[];
-  title?: string;
-  description?: string;
-  enum?: unknown[];
-  oneOf?: JsonSchemaLike[];
-  properties?: Record<string, JsonSchemaLike>;
-  items?: JsonSchemaLike;
-  required?: string[];
-  format?: string;
-  default?: unknown;
-  [key: string]: unknown;
-}
+import { isRecord, oneOfBranchTag, resolveRef, type JsonSchemaLike } from "./schemaCore";
 
-/**
- * Resolves `$ref` pointers against the standalone schema document they came
- * from. Definitions endpoints serve draft 2020-12 documents with dependencies
- * under `$defs`, so `#/$defs/Name` is the shape in play. Sibling keywords next
- * to `$ref` (e.g. a `description`) win over the target. Returns undefined for
- * pointers the document does not contain.
- */
-export function resolveRef(
-  schema: JsonSchemaLike,
-  doc?: JsonSchemaLike,
-): JsonSchemaLike | undefined {
-  if (!schema.$ref) return schema;
-  const prefix = "#/$defs/";
-  if (!schema.$ref.startsWith(prefix) || !doc?.$defs) return undefined;
-  const name = schema.$ref.slice(prefix.length);
-  const target = doc.$defs[name];
-  if (!target) return undefined;
-  const { $ref: _, ...siblings } = schema;
-  return { ...resolveRef(target, doc), ...siblings };
-}
+export type { JsonSchemaLike } from "./schemaCore";
 
 /**
  * Picks the `oneOf` branch the given value matches. Prefers a literal
@@ -44,31 +11,22 @@ export function pickOneOfBranch(
   branches: JsonSchemaLike[],
   value: unknown,
 ): JsonSchemaLike | undefined {
-  if (typeof value !== "object" || value === null) return undefined;
-  const record = value as Record<string, unknown>;
+  if (!isRecord(value)) return undefined;
 
   for (const branch of branches) {
-    const tag = tagValue(branch);
-    if (tag && recordMatchesTag(record, tag)) return branch;
+    const tag = oneOfBranchTag(branch);
+    if (tag && recordMatchesTag(value, tag)) return branch;
   }
 
   let best: { branch: JsonSchemaLike; score: number } | undefined;
   for (const branch of branches) {
-    const required = (branch.required ?? []).filter((k) => k in record);
+    const required = (branch.required ?? []).filter((k) => k in value);
     if (required.length === 0) continue;
     const total = branch.required?.length ?? 0;
     const score = required.length / total;
     if (!best || score > best.score) best = { branch, score };
   }
   return best?.branch;
-}
-
-function tagValue(branch: JsonSchemaLike): [string, unknown] | undefined {
-  for (const key of ["type", "kind", "key"]) {
-    const prop = branch.properties?.[key];
-    if (prop?.enum?.length === 1) return [key, prop.enum[0]];
-  }
-  return undefined;
 }
 
 function recordMatchesTag(record: Record<string, unknown>, [key, expected]: [string, unknown]) {

--- a/app/utils/schemaForm.ts
+++ b/app/utils/schemaForm.ts
@@ -1,20 +1,14 @@
 import * as z from "zod/v4/mini";
-import { resolveRef, type JsonSchemaLike } from "~/utils/schemaDisplay";
+import { oneOfBranchTag, resolveRef, stringEnums, type JsonSchemaLike, typeOf } from "./schemaCore";
 
 export type FormValue =
   string | number | boolean | null | FormValue[] | { [key: string]: FormValue };
 export type FormState = { [key: string]: FormValue };
 
-function typeOf(schema: JsonSchemaLike): string | undefined {
-  if (typeof schema.type === "string") return schema.type;
-  if (Array.isArray(schema.type)) return schema.type.find((t) => t !== "null");
-  return undefined;
-}
-
 /**
  * The branch a `oneOf` schema should use for form state. A single tagged
- * branch (`type`/`kind` enum with one value) is auto-selected; with several
- * candidates the caller must let the user choose.
+ * branch (`type`/`kind`/`key` enum with one value) is auto-selected; with
+ * several candidates the caller must let the user choose.
  */
 export function defaultOneOfBranch(
   schema: JsonSchemaLike,
@@ -24,17 +18,9 @@ export function defaultOneOfBranch(
   if (tagged.length === 1) {
     const branch = tagged[0]!;
     const tag = oneOfBranchTag(branch);
-    return tag ? { branch, tag } : { branch };
+    return tag ? { branch, tag: [tag[0], tag[1] as FormValue] } : { branch };
   }
   if (schema.oneOf.length === 1) return { branch: schema.oneOf[0]! };
-  return undefined;
-}
-
-export function oneOfBranchTag(branch: JsonSchemaLike): [string, FormValue] | undefined {
-  for (const key of ["type", "kind"]) {
-    const value = branch.properties?.[key]?.enum?.[0];
-    if (value !== undefined) return [key, value as FormValue];
-  }
   return undefined;
 }
 
@@ -90,9 +76,11 @@ export function buildFormState(schemaIn: JsonSchemaLike, doc?: JsonSchemaLike): 
       case "boolean":
         state[key] = false;
         break;
-      default:
-        state[key] = "";
+      default: {
+        const values = stringEnums(prop);
+        state[key] = values?.length === 1 ? (values[0] ?? "") : "";
         break;
+      }
     }
   }
   return state;
@@ -130,7 +118,8 @@ export function mergeFormState(seed: FormState, value: unknown): FormState {
 /**
  * Strips empty-string and empty-array placeholders and converts numeric
  * fields (kept as strings for the inputs) to numbers, so the request body
- * only carries values the user actually entered.
+ * only carries values the user actually entered. Numeric conversion resolves
+ * `$ref` targets, array item schemas, and the auto-selected `oneOf` branch.
  */
 export function cleanFormState(
   state: FormState,
@@ -142,38 +131,59 @@ export function cleanFormState(
   const out: FormState = {};
   for (const [key, value] of Object.entries(state)) {
     if (value === "") continue;
+    const prop = schema?.properties?.[key] ? resolveRef(schema.properties[key], docRef) : undefined;
     if (Array.isArray(value)) {
       if (value.length === 0) continue;
-      const items = schema?.properties?.[key]?.items;
-      out[key] = value.map((v) => (isFormState(v) ? cleanFormState(v, items, docRef) : v));
+      const items = prop?.items ? resolveRef(prop.items, docRef) : undefined;
+      out[key] = value.map((v) =>
+        isFormState(v) ? cleanFormState(v, items, docRef) : (toNumber(v, items) ?? v),
+      );
       continue;
     }
     if (isFormState(value)) {
-      out[key] = cleanFormState(value, schema?.properties?.[key], docRef);
+      let sub = prop;
+      if (sub?.oneOf?.length) sub = defaultOneOfBranch(sub)?.branch;
+      out[key] = cleanFormState(value, sub, docRef);
       continue;
     }
-    if (
-      typeof value === "string" &&
-      (typeOf(schema?.properties?.[key] ?? {}) === "number" ||
-        typeOf(schema?.properties?.[key] ?? {}) === "integer") &&
-      value.trim() !== "" &&
-      !Number.isNaN(Number(value))
-    ) {
-      out[key] = Number(value);
-      continue;
-    }
-    out[key] = value;
+    out[key] = toNumber(value, prop) ?? value;
   }
   return out;
 }
 
-const NUMBER_RE = /^-?\d+(\.\d+)?$/;
+function toNumber(value: unknown, schema?: JsonSchemaLike): number | undefined {
+  const t = typeOf(schema ?? {});
+  if (
+    (t === "number" || t === "integer") &&
+    typeof value === "string" &&
+    value.trim() !== "" &&
+    !Number.isNaN(Number(value))
+  ) {
+    return Number(value);
+  }
+  return undefined;
+}
+
+const NUMBER_RE = /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/;
 const INTEGER_RE = /^-?\d+$/;
 
 /**
+ * Wraps a numeric predicate as a zod check for string-backed number fields.
+ * The zod/v4/mini check protocol hands the payload with `.value` and expects
+ * issues pushed, not a boolean return.
+ */
+function numericCheck(pred: (value: string) => boolean) {
+  return z.check((payload: z.core.ParsePayload<string>) => {
+    if (pred(payload.value)) return;
+    payload.issues.push({ code: "custom", input: payload.value });
+  });
+}
+
+/**
  * Builds a zod schema validating form state against the JSON Schema:
- * required checks, enum domains, numeric strings, nested objects, and
- * arrays. Optional fields accept the empty-string placeholder.
+ * required checks, enum domains, numeric strings, nested objects, arrays,
+ * and the declared string/number/array constraints. Optional fields accept
+ * the empty-string placeholder.
  */
 export function buildZodSchema(
   schemaIn: JsonSchemaLike,
@@ -203,15 +213,28 @@ export function buildZodSchema(
     }
     case "array": {
       const items = schema.items ? buildZodSchema(schema.items, true, docRef) : z.any();
-      const arr = z.array(items);
-      return required ? arr.check(z.minLength(1)) : arr;
+      let arr = z.array(items);
+      if (schema.minItems !== undefined) arr = arr.check(z.minLength(schema.minItems));
+      return required ? arr.check(z.minLength(Math.max(1, schema.minItems ?? 1))) : arr;
     }
     case "boolean":
       return z.boolean();
     case "number":
     case "integer": {
       const re = typeOf(schema) === "integer" ? INTEGER_RE : NUMBER_RE;
-      const num = z.string().check(z.regex(re));
+      let num = z.string().check(z.regex(re));
+      const min = schema.minimum;
+      if (min !== undefined) num = num.check(numericCheck((value) => Number(value) >= min));
+      const max = schema.maximum;
+      if (max !== undefined) num = num.check(numericCheck((value) => Number(value) <= max));
+      const exclusiveMinimum = schema.exclusiveMinimum;
+      if (exclusiveMinimum !== undefined) {
+        num = num.check(numericCheck((value) => Number(value) > exclusiveMinimum));
+      }
+      const exclusiveMaximum = schema.exclusiveMaximum;
+      if (exclusiveMaximum !== undefined) {
+        num = num.check(numericCheck((value) => Number(value) < exclusiveMaximum));
+      }
       return required ? num.check(z.minLength(1)) : num;
     }
     case "string": {
@@ -219,7 +242,14 @@ export function buildZodSchema(
         const values: [string, ...string[]] = schema.enum as [string, ...string[]];
         return z.enum(values);
       }
-      return required ? z.string().check(z.minLength(1)) : z.string();
+      let str = z.string();
+      const minLength = schema.minLength;
+      if (minLength !== undefined) str = str.check(z.minLength(minLength));
+      const maxLength = schema.maxLength;
+      if (maxLength !== undefined) str = str.check(z.maxLength(maxLength));
+      const pattern = schema.pattern;
+      if (pattern !== undefined) str = str.check(z.regex(new RegExp(pattern)));
+      return required ? str.check(z.minLength(1)) : str;
     }
     default:
       return z.any();

--- a/test/schemaDisplay.test.ts
+++ b/test/schemaDisplay.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
-import {
-  pickOneOfBranch,
-  resolveRef,
-  schemaEntries,
-  type JsonSchemaLike,
-} from "~/utils/schemaDisplay";
+import { pickOneOfBranch, schemaEntries } from "~/utils/schemaDisplay";
+import { resolveRef, type JsonSchemaLike } from "~/utils/schemaCore";
 
 // Mirrors the standalone documents the definitions endpoints serve:
 // dependencies under $defs, refs as #/$defs/Name.
@@ -94,6 +90,29 @@ describe("pickOneOfBranch", () => {
 
   it("returns undefined when no branch matches", () => {
     expect(pickOneOfBranch(branches, { unrelated: true })).toBeUndefined();
+  });
+
+  it("recognizes a branch tagged via a key property enum", () => {
+    const keyed: JsonSchemaLike[] = [
+      {
+        type: "object",
+        required: ["key", "value"],
+        properties: {
+          key: { type: "string", enum: ["checksum"] },
+          value: { type: "string" },
+        },
+      },
+      {
+        type: "object",
+        required: ["key", "data"],
+        properties: {
+          key: { type: "string", enum: ["blob"] },
+          data: { type: "string" },
+        },
+      },
+    ];
+    expect(pickOneOfBranch(keyed, { key: "blob", data: "..." })).toBe(keyed[1]);
+    expect(pickOneOfBranch(keyed, { key: "checksum", value: "..." })).toBe(keyed[0]);
   });
 });
 

--- a/test/schemaForm.test.ts
+++ b/test/schemaForm.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from "vitest";
 import * as z from "zod/v4/mini";
-import type { JsonSchemaLike } from "~/utils/schemaDisplay";
+import { oneOfBranchTag, type JsonSchemaLike } from "~/utils/schemaCore";
 import {
   buildFormState,
   buildZodSchema,
   cleanFormState,
   defaultOneOfBranch,
   mergeFormState,
-  oneOfBranchTag,
   type FormState,
 } from "~/utils/schemaForm";
 
@@ -87,6 +86,14 @@ describe("buildFormState", () => {
   it("returns an empty state without properties", () => {
     expect(buildFormState({ type: "object" })).toEqual({});
   });
+
+  it("seeds a single-value string enum without a default", () => {
+    const state = buildFormState({
+      type: "object",
+      properties: { kind: { type: "string", enum: ["cron"] } },
+    });
+    expect(state.kind).toBe("cron");
+  });
 });
 
 describe("cleanFormState", () => {
@@ -107,6 +114,44 @@ describe("cleanFormState", () => {
 
   it("keeps booleans as booleans", () => {
     expect(cleanFormState({ verbose: true }, downloadInput)).toEqual({ verbose: true });
+  });
+
+  it("converts numeric strings behind a $ref", () => {
+    const schema: JsonSchemaLike = {
+      $defs: { Secs: { type: "number" } },
+      type: "object",
+      properties: { timeout: { $ref: "#/$defs/Secs" } },
+    };
+    expect(cleanFormState({ timeout: "5" }, schema)).toEqual({ timeout: 5 });
+  });
+
+  it("converts numeric array items", () => {
+    const schema: JsonSchemaLike = {
+      type: "object",
+      properties: { ids: { type: "array", items: { type: "integer" } } },
+    };
+    expect(cleanFormState({ ids: ["1", "2"] }, schema)).toEqual({ ids: [1, 2] });
+  });
+
+  it("converts numeric leaves inside a single-branch oneOf property", () => {
+    const schema: JsonSchemaLike = {
+      type: "object",
+      properties: {
+        job: {
+          oneOf: [
+            {
+              type: "object",
+              properties: {
+                kind: { type: "string", enum: ["cron"] },
+                retries: { type: "integer" },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const state = { job: { kind: "cron", retries: "3" } };
+    expect(cleanFormState(state, schema)).toEqual({ job: { kind: "cron", retries: 3 } });
   });
 });
 
@@ -153,6 +198,39 @@ describe("buildZodSchema", () => {
 
     const badTag = { key: "k", source: { reference: "r", media_type: "m", type: "docker" } };
     expect(z.safeParse(schema, badTag).success).toBe(false);
+  });
+
+  it("accepts scientific notation for type number", () => {
+    const numSchema = buildZodSchema({ type: "number" });
+    expect(z.safeParse(numSchema, "1e3").success).toBe(true);
+    expect(z.safeParse(numSchema, "1.5E-2").success).toBe(true);
+    expect(z.safeParse(numSchema, "-2e+10").success).toBe(true);
+    expect(z.safeParse(numSchema, "abc").success).toBe(false);
+  });
+
+  it("enforces minimum on numeric strings", () => {
+    const minSchema = buildZodSchema({ type: "integer", minimum: 0 });
+    expect(z.safeParse(minSchema, "3").success).toBe(true);
+    expect(z.safeParse(minSchema, "-5").success).toBe(false);
+  });
+
+  it("enforces pattern on strings", () => {
+    const patternSchema = buildZodSchema({ type: "string", pattern: "^[a-z]+$" });
+    expect(z.safeParse(patternSchema, "abc").success).toBe(true);
+    expect(z.safeParse(patternSchema, "ABC").success).toBe(false);
+  });
+
+  it("enforces minLength and maxLength on strings", () => {
+    const lenSchema = buildZodSchema({ type: "string", minLength: 2, maxLength: 4 });
+    expect(z.safeParse(lenSchema, "abc").success).toBe(true);
+    expect(z.safeParse(lenSchema, "a").success).toBe(false);
+    expect(z.safeParse(lenSchema, "abcdef").success).toBe(false);
+  });
+
+  it("enforces minItems on arrays", () => {
+    const arrSchema = buildZodSchema({ type: "array", items: { type: "string" }, minItems: 2 });
+    expect(z.safeParse(arrSchema, ["a", "b"]).success).toBe(true);
+    expect(z.safeParse(arrSchema, ["a"]).success).toBe(false);
   });
 });
 


### PR DESCRIPTION
Shared helpers move to a new schemaCore module so form and display agree on tags and types. Numbers now convert correctly behind $ref, inside array items, and inside oneOf branches. Forms enforce string and numeric constraints and render root-level oneOf schemas.