### PR TITLE
fix: operations and settings review follow-ups

### DIFF
--- a/app/components/IntervalInput.vue
+++ b/app/components/IntervalInput.vue
@@ -65,6 +65,12 @@ watch([valueText, unit], () => {
       class="flex-1"
       @update:model-value="(v) => (valueText = v ?? '')"
     />
-    <USelectMenu v-model="unit" :items="unitItems" value-key="value" class="w-32" />
+    <USelectMenu
+      v-model="unit"
+      :items="unitItems"
+      value-key="value"
+      class="w-32"
+      :aria-label="$t('operations.schedules.intervalUnit')"
+    />
   </div>
 </template>

--- a/app/composables/useCursorPager.ts
+++ b/app/composables/useCursorPager.ts
@@ -26,6 +26,16 @@ export function useCursorPager<T, P extends object = Record<string, never>>(
   let gen = 0;
 
   async function load(cursor?: string) {
+    if (params && params() === undefined) {
+      gen++;
+      items.value = [];
+      error.value = null;
+      nextCursor.value = null;
+      prevCursor.value = null;
+      currentCursor.value = undefined;
+      pending.value = false;
+      return;
+    }
     const myGen = ++gen;
     pending.value = true;
     error.value = null;
@@ -49,12 +59,12 @@ export function useCursorPager<T, P extends object = Record<string, never>>(
   const hasPrev = computed(() => prevCursor.value !== null);
 
   function loadNext() {
-    if (nextCursor.value === null) return;
+    if (pending.value || nextCursor.value === null) return;
     void load(nextCursor.value);
   }
 
   function loadPrev() {
-    if (prevCursor.value === null) return;
+    if (pending.value || prevCursor.value === null) return;
     void load(prevCursor.value);
   }
 
@@ -64,7 +74,15 @@ export function useCursorPager<T, P extends object = Record<string, never>>(
 
   if (import.meta.client) {
     const paramsKey = computed(() => JSON.stringify(params?.() ?? null));
-    watch(paramsKey, () => void load(undefined), { immediate: true });
+    watch(
+      paramsKey,
+      () => {
+        items.value = [];
+        error.value = null;
+        void load(undefined);
+      },
+      { immediate: true },
+    );
   }
 
   return { items, pending, error, hasNext, hasPrev, loadNext, loadPrev, reload };

--- a/app/composables/useLogsFilters.ts
+++ b/app/composables/useLogsFilters.ts
@@ -62,7 +62,7 @@ const expandCodec = z.codec(
   },
 );
 
-export const schema = z.object({
+export const logsSchema = z.object({
   level: queryLogLevel(DEFAULT_LEVEL),
   target: queryStringArray(),
   search: queryOptionalString(),
@@ -75,9 +75,9 @@ export const schema = z.object({
   until: querySingle(instantCodec),
 });
 
-export type LogsState = z.infer<typeof schema>;
+export type LogsState = z.infer<typeof logsSchema>;
 
-export const queryKeys: Partial<Record<keyof LogsState, string>> = {
+export const logsQueryKeys: Partial<Record<keyof LogsState, string>> = {
   search: "q",
   timeRange: "range",
   bootId: "boot",

--- a/app/composables/useRouteQueryState.ts
+++ b/app/composables/useRouteQueryState.ts
@@ -109,9 +109,15 @@ export function useRouteQueryState<S extends z.core.$ZodObject>(
   watch(
     state,
     () => {
-      const query = serialize();
-      if (queryEquals(query, cachedQuery)) return;
-      cachedQuery = query;
+      const own = serialize();
+      if (queryEquals(own, cachedQuery)) return;
+      cachedQuery = own;
+      const ownUrlKeys = new Set(stateKeys.map(toUrlKey));
+      const query: Record<string, RouteQueryRaw> = {};
+      for (const [k, v] of Object.entries(route.query)) {
+        if (!ownUrlKeys.has(k)) query[k] = v as RouteQueryRaw;
+      }
+      Object.assign(query, own);
       void router.replace({ query });
     },
     { deep: true },

--- a/app/composables/useTasksFilters.ts
+++ b/app/composables/useTasksFilters.ts
@@ -45,10 +45,6 @@ export const tasksQueryKeys: Partial<Record<keyof TasksFilters, string>> = {
   root: "root",
 };
 
-export function defaultTasksFilters(): TasksFilters {
-  return { status: undefined, key: undefined, root: true };
-}
-
 export function useTasksFilters(): TasksFilters {
   return useRouteQueryState(tasksSchema, { keys: tasksQueryKeys });
 }

--- a/app/pages/developer/logs.vue
+++ b/app/pages/developer/logs.vue
@@ -6,7 +6,7 @@ import type {
   LogEvent,
   LogSpan,
 } from "~~/modules/aperture/runtime/types";
-import { defaultLogsState, queryKeys, schema } from "~/composables/useLogsFilters";
+import { defaultLogsState, logsQueryKeys, logsSchema } from "~/composables/useLogsFilters";
 import { timeRangeDurations, useLogsContextKey } from "~/composables/useLogsContext";
 import { LEVEL_COLORS, LOG_LEVELS } from "~/utils/logLevels";
 
@@ -16,7 +16,7 @@ const route = useRoute();
 const router = useRouter();
 const localePath = useLocalePath();
 
-const filters = useRouteQueryState(schema, { keys: queryKeys });
+const filters = useRouteQueryState(logsSchema, { keys: logsQueryKeys });
 
 const {
   items: targetItemsRaw,

--- a/app/pages/operations/artifacts.vue
+++ b/app/pages/operations/artifacts.vue
@@ -7,6 +7,7 @@ import type {
   ListArtifactVersionsParams,
 } from "~~/modules/aperture/runtime/types";
 import {
+  ARTIFACT_SORTS,
   artifactsParamsFromFilters,
   useArtifactsFilters,
   useArtifactVersionsFilters,
@@ -17,6 +18,7 @@ import { bytesToUnit } from "~/utils/formatBytes";
 const { t } = useI18n();
 const toast = useToast();
 const fmt = useFormatter();
+const localePath = useLocalePath();
 
 const filters = useArtifactsFilters();
 const versionFilters = useArtifactVersionsFilters();
@@ -60,13 +62,6 @@ const {
 
 const selectedKey = computed(() => filters.key);
 
-function openKey(key: string) {
-  filters.key = key;
-  versionFilters.media_type = undefined;
-  versionFilters.version = undefined;
-  versionFilters.sort = undefined;
-}
-
 // Versions view.
 
 const versionsParams = computed<ListArtifactVersionsParams>(() =>
@@ -87,9 +82,17 @@ const {
   () => (selectedKey.value ? versionsParams.value : undefined),
 );
 
+const SORT_LABEL_KEYS = {
+  downloaded_at: "downloadedAt",
+  size_bytes: "sizeBytes",
+} as const;
+
 const sortItems = computed<SelectMenuItem[]>(() => [
-  { label: t("operations.artifacts.sort.downloadedAt"), value: "downloaded_at" },
-  { label: t("operations.artifacts.sort.sizeBytes"), value: "size_bytes" },
+  { label: t("operations.artifacts.sort.default"), value: undefined },
+  ...ARTIFACT_SORTS.map((s) => ({
+    label: t(`operations.artifacts.sort.${SORT_LABEL_KEYS[s]}`),
+    value: s,
+  })),
 ]);
 
 async function onEvict(version: ArtifactVersion) {
@@ -140,7 +143,7 @@ async function onUpload() {
     uploadOpen.value = false;
     toast.add({ title: t("operations.artifacts.uploaded"), color: "success" });
     if (selectedKey.value && selectedKey.value === uploadKey.value.trim()) {
-      await versionsReload();
+      await Promise.all([versionsReload(), listReload()]);
     } else {
       await listReload();
     }
@@ -197,6 +200,7 @@ async function onUpload() {
             value-key="value"
             size="sm"
             class="w-44"
+            :aria-label="$t('operations.artifacts.filters.sort')"
           />
         </template>
 
@@ -234,8 +238,7 @@ async function onUpload() {
             v-for="artifact in artifacts"
             :key="artifact.key"
             variant="subtle"
-            class="cursor-pointer"
-            @click="openKey(artifact.key)"
+            :to="localePath({ path: '/operations/artifacts', query: { key: artifact.key } })"
           >
             <div class="flex flex-wrap sm:items-center justify-between gap-3">
               <div class="flex items-center gap-3 min-w-0">
@@ -287,8 +290,8 @@ async function onUpload() {
                   {{ version.digest }}
                 </span>
                 <span class="text-muted text-xs">
-                  <template v-if="version.version">{{ version.version }} · </template>
-                  <template v-if="version.media_type">{{ version.media_type }} · </template>
+                  <template v-if="version.version">{{ version.version }} / </template>
+                  <template v-if="version.media_type">{{ version.media_type }} / </template>
                   {{ formatBytes(version.size_bytes) }}
                 </span>
               </div>

--- a/app/pages/operations/schedules.vue
+++ b/app/pages/operations/schedules.vue
@@ -2,7 +2,8 @@
 import type { SelectMenuItem } from "@nuxt/ui";
 import * as z from "zod/v4/mini";
 import type { ListTaskSchedulesParams, TaskSchedule } from "~~/modules/aperture/runtime/types";
-import type { JsonSchemaLike } from "~/utils/schemaDisplay";
+import type { JsonSchemaLike } from "~/utils/schemaCore";
+import { durationToUnitCombo } from "~/utils/scheduleInterval";
 import { buildFormState, buildZodSchema, cleanFormState, type FormState } from "~/utils/schemaForm";
 import {
   useTaskDefinitionCache,
@@ -93,11 +94,12 @@ function formatInterval(schedule: TaskSchedule): string {
   return fmt.duration(Temporal.Duration.from(schedule.interval), { fractionDigits: 1 });
 }
 
-async function toggleEnabled(schedule: TaskSchedule) {
-  const next = !schedule.enabled;
+async function toggleEnabled(schedule: TaskSchedule, value?: boolean) {
+  const next = value ?? !schedule.enabled;
   schedule.enabled = next;
   try {
-    await apertureApi.updateTaskSchedule(schedule.id, { enabled: next });
+    const updated = await apertureApi.updateTaskSchedule(schedule.id, { enabled: next });
+    Object.assign(schedule, updated);
   } catch {
     schedule.enabled = !next;
     toast.add({ title: t("operations.schedules.updateFailed"), color: "error" });
@@ -131,7 +133,7 @@ const createZodSchema = computed(() =>
   createInputSchema.value ? buildZodSchema(createInputSchema.value) : z.object({}),
 );
 
-watch(createKey, async (key) => {
+async function applyCreateKey(key: string | undefined) {
   createState.value = {};
   createInputSchema.value = undefined;
   if (!key) return;
@@ -143,10 +145,13 @@ watch(createKey, async (key) => {
   if (createInputSchema.value) {
     createState.value = buildFormState(createInputSchema.value);
   }
-});
+}
+
+watch(createKey, (key) => void applyCreateKey(key));
 
 function openCreate() {
   createKey.value = definitionSummaries.value[0]?.key;
+  void applyCreateKey(createKey.value);
   createInterval.value = undefined;
   createOpen.value = true;
 }
@@ -175,21 +180,48 @@ async function onCreate() {
 const editOpen = ref(false);
 const editTarget = ref<TaskSchedule | null>(null);
 const editInterval = ref<Temporal.Duration | undefined>(undefined);
+const editIntervalRaw = ref<string | null>(null);
 const editing = ref(false);
 
 function openEdit(schedule: TaskSchedule) {
   editTarget.value = schedule;
-  editInterval.value = Temporal.Duration.from(schedule.interval);
+  const duration = Temporal.Duration.from(schedule.interval);
+  const combo = durationToUnitCombo(duration);
+  if (combo) {
+    editInterval.value = duration;
+    editIntervalRaw.value = null;
+  } else {
+    // Sub-second intervals have no value+unit form; keep the raw string.
+    editInterval.value = undefined;
+    editIntervalRaw.value = schedule.interval;
+  }
   editOpen.value = true;
 }
 
+const editIntervalValid = computed(() => {
+  if (editIntervalRaw.value !== null) {
+    try {
+      Temporal.Duration.from(editIntervalRaw.value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return editInterval.value !== undefined;
+});
+
 async function onEdit() {
-  if (!editTarget.value || !editInterval.value) return;
+  if (!editTarget.value || !editIntervalValid.value) return;
+  let interval: string;
+  if (editIntervalRaw.value !== null) {
+    interval = editIntervalRaw.value;
+  } else {
+    if (!editInterval.value) return;
+    interval = editInterval.value.toString();
+  }
   editing.value = true;
   try {
-    await apertureApi.updateTaskSchedule(editTarget.value.id, {
-      interval: editInterval.value.toString(),
-    });
+    await apertureApi.updateTaskSchedule(editTarget.value.id, { interval });
     editOpen.value = false;
     toast.add({ title: t("operations.schedules.edited"), color: "success" });
     await reload();
@@ -241,7 +273,8 @@ async function onEdit() {
                 <div class="flex items-center gap-3 min-w-0">
                   <USwitch
                     :model-value="schedule.enabled"
-                    @update:model-value="() => toggleEnabled(schedule)"
+                    :aria-label="$t('operations.schedules.enabled')"
+                    @update:model-value="(value) => toggleEnabled(schedule, value)"
                   />
                   <span class="font-mono text-sm truncate">{{ schedule.key }}</span>
                   <UBadge :label="formatInterval(schedule)" variant="subtle" />
@@ -284,6 +317,7 @@ async function onEdit() {
                     color="error"
                     variant="ghost"
                     size="xs"
+                    :aria-label="$t('operations.schedules.deleteAction')"
                     @click="onDelete(schedule)"
                   />
                 </div>
@@ -374,17 +408,25 @@ async function onEdit() {
       <template #body>
         <div class="flex flex-col gap-4">
           <UFormField
+            v-if="editIntervalRaw === null"
             :label="$t('operations.schedules.interval')"
-            :help="!editInterval ? $t('operations.schedules.invalidInterval') : undefined"
+            :help="!editIntervalValid ? $t('operations.schedules.invalidInterval') : undefined"
           >
             <IntervalInput v-model="editInterval" />
+          </UFormField>
+          <UFormField
+            v-else
+            :label="$t('operations.schedules.intervalRaw')"
+            :help="!editIntervalValid ? $t('operations.schedules.invalidInterval') : undefined"
+          >
+            <UInput v-model="editIntervalRaw" class="font-mono" />
           </UFormField>
           <div class="flex justify-end gap-2">
             <UButton variant="ghost" :label="$t('common.cancel')" @click="editOpen = false" />
             <UButton
               :loading="editing"
               :label="$t('common.save')"
-              :disabled="!editInterval"
+              :disabled="!editIntervalValid"
               @click="onEdit()"
             />
           </div>

--- a/app/pages/operations/tasks/[id].vue
+++ b/app/pages/operations/tasks/[id].vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useIntervalFn } from "@vueuse/core";
 import type { ListTasksParams, Task, TaskDefinition } from "~~/modules/aperture/runtime/types";
-import type { JsonSchemaLike } from "~/utils/schemaDisplay";
+import type { JsonSchemaLike } from "~/utils/schemaCore";
 import { useTaskDefinitionCache } from "~/composables/useTaskDefinitions";
 import { TASK_STATUS_COLORS, useTaskDisplay } from "~/composables/useTaskDisplay";
 
@@ -25,7 +25,9 @@ watch(
   async (key) => {
     definition.value = undefined;
     if (!key) return;
-    definition.value = await getDefinition(key);
+    const def = await getDefinition(key);
+    if (task.value?.key !== key) return;
+    definition.value = def;
   },
 );
 
@@ -52,7 +54,9 @@ const isActive = computed(
   () => task.value?.status === "pending" || task.value?.status === "running",
 );
 
-const { pause, resume } = useIntervalFn(() => void load(), 3000);
+const { pause, resume } = useIntervalFn(() => {
+  if (!loading.value) void load();
+}, 3000);
 
 watch(isActive, (active) => (active ? resume() : pause()), { immediate: true });
 
@@ -114,7 +118,7 @@ const {
     <div class="p-4 flex flex-col gap-4">
       <DataState
         :pending="loading && !task"
-        :error="loadError ? String(loadError) : null"
+        :error="!task && loadError ? String(loadError) : null"
         :error-text="$t('operations.tasks.error')"
         :retry-text="$t('common.retry')"
         @retry="load()"
@@ -149,7 +153,7 @@ const {
                     variant="ghost"
                     size="sm"
                     :label="$t('operations.tasks.refresh')"
-                    :loading="loading"
+                    :loading="loading && !task"
                     @click="load()"
                   />
                 </div>
@@ -275,7 +279,7 @@ const {
           <UPageCard :title="$t('operations.tasks.detail.children')" variant="subtle">
             <DataState
               :pending="childrenPending && children.length === 0"
-              :error="childrenError ? String(childrenError) : null"
+              :error="children.length === 0 && childrenError ? String(childrenError) : null"
               :empty="children.length === 0"
               :empty-text="$t('operations.tasks.detail.noChildren')"
               :error-text="$t('operations.tasks.error')"

--- a/app/pages/operations/tasks/index.vue
+++ b/app/pages/operations/tasks/index.vue
@@ -3,7 +3,7 @@ import type { SelectMenuItem } from "@nuxt/ui";
 import * as z from "zod/v4/mini";
 import { useIntervalFn } from "@vueuse/core";
 import type { CreateTaskBody, ListTasksParams, Task } from "~~/modules/aperture/runtime/types";
-import type { JsonSchemaLike } from "~/utils/schemaDisplay";
+import type { JsonSchemaLike } from "~/utils/schemaCore";
 import { buildFormState, buildZodSchema, cleanFormState, type FormState } from "~/utils/schemaForm";
 import {
   TASK_STATUS_FILTERS,
@@ -56,15 +56,18 @@ const statusItems = computed<SelectMenuItem[]>(() => [
   })),
 ]);
 
-const keyItems = computed<SelectMenuItem[]>(() =>
-  definitionSummaries.value.map((d) => ({ label: d.key, value: d.key })),
-);
+const keyItems = computed<SelectMenuItem[]>(() => [
+  { label: t("operations.tasks.filters.keyAll"), value: undefined },
+  ...definitionSummaries.value.map((d) => ({ label: d.key, value: d.key })),
+]);
 
 const hasActiveTasks = computed(() =>
   tasks.value.some((task) => task.status === "pending" || task.status === "running"),
 );
 
-const { pause, resume } = useIntervalFn(() => void reload(), 3000);
+const { pause, resume } = useIntervalFn(() => {
+  if (!pending.value) void reload();
+}, 3000);
 
 watch(hasActiveTasks, (active) => (active ? resume() : pause()), { immediate: true });
 
@@ -82,22 +85,25 @@ const createZodSchema = computed(() =>
   createInputSchema.value ? buildZodSchema(createInputSchema.value) : z.object({}),
 );
 
-watch(createKey, async (key) => {
+async function applyCreateKey(key: string | undefined) {
   createState.value = {};
   createInputSchema.value = undefined;
   if (!key) return;
   const definition = await getDefinition(key);
-  const schema = definition?.input_schema;
   if (createKey.value !== key) return;
+  const schema = definition?.input_schema;
   createInputSchema.value =
     typeof schema === "object" && schema !== null ? (schema as JsonSchemaLike) : undefined;
   if (createInputSchema.value) {
     createState.value = buildFormState(createInputSchema.value);
   }
-});
+}
+
+watch(createKey, (key) => void applyCreateKey(key));
 
 function openCreate() {
   createKey.value = definitionSummaries.value[0]?.key;
+  void applyCreateKey(createKey.value);
   createOpen.value = true;
 }
 
@@ -111,6 +117,7 @@ async function onCreate() {
     };
     await apertureApi.createTask(body);
     createOpen.value = false;
+    createState.value = {};
     toast.add({ title: t("operations.tasks.created"), color: "success" });
     await reload();
   } catch (err) {
@@ -137,6 +144,7 @@ async function onCreate() {
           value-key="value"
           size="sm"
           class="w-44"
+          :aria-label="$t('operations.tasks.filters.status')"
         />
 
         <InfiniteSelectMenu
@@ -147,6 +155,7 @@ async function onCreate() {
           value-key="value"
           size="sm"
           class="w-44"
+          :aria-label="$t('operations.tasks.filters.key')"
           @load-more="loadMoreDefinitions()"
         />
 
@@ -181,7 +190,7 @@ async function onCreate() {
     <div class="p-4">
       <DataState
         :pending="pending && tasks.length === 0"
-        :error="error ? String(error) : null"
+        :error="tasks.length === 0 && error ? String(error) : null"
         :empty="tasks.length === 0"
         :empty-text="$t('operations.tasks.empty')"
         :error-text="$t('operations.tasks.error')"

--- a/app/pages/settings/system.vue
+++ b/app/pages/settings/system.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import * as z from "zod/v4/mini";
 import type { Setting } from "~~/modules/aperture/runtime/types";
-import type { JsonSchemaLike } from "~/utils/schemaDisplay";
+import type { JsonSchemaLike } from "~/utils/schemaCore";
 import {
   buildFormState,
   buildZodSchema,
@@ -9,10 +9,7 @@ import {
   mergeFormState,
   type FormState,
 } from "~/utils/schemaForm";
-import {
-  useSettingDefinitionCache,
-  useSettingDefinitionSummaries,
-} from "~/composables/useSettingDefinitions";
+import { useSettingDefinitionCache } from "~/composables/useSettingDefinitions";
 
 const { t } = useI18n();
 const toast = useToast();
@@ -24,7 +21,6 @@ const { data, pending, error, refresh } = await useAsyncData<Setting[]>(
   { server: false },
 );
 
-useSettingDefinitionSummaries();
 const { getDefinition } = useSettingDefinitionCache();
 
 const schemas = ref<Map<string, JsonSchemaLike | undefined>>(new Map());

--- a/app/utils/schemaDisplay.ts
+++ b/app/utils/schemaDisplay.ts
@@ -1,7 +1,5 @@
 import { isRecord, oneOfBranchTag, resolveRef, type JsonSchemaLike } from "./schemaCore";
 
-export type { JsonSchemaLike } from "./schemaCore";
-
 /**
  * Picks the `oneOf` branch the given value matches. Prefers a literal
  * discriminator (`type`/`kind`/`key` enum constant), then falls back to

--- a/e2e/artifacts.spec.ts
+++ b/e2e/artifacts.spec.ts
@@ -105,8 +105,9 @@ test("artifacts list, versions view, download, and evict", async ({ page }) => {
   await expect(page.getByText("spectra", { exact: true })).toBeVisible();
   await expect(page.getByText("3 versions")).toBeVisible();
 
-  // Open the versions view for the key.
-  await page.getByText("spectra", { exact: true }).click();
+  // Open the versions view for the key. The card is one big link overlay
+  // (the anchor has no box; its inset span is the hit area).
+  await page.getByRole("link", { name: "Card link" }).locator("span").click();
   await expect(page).toHaveURL(/key=spectra/);
   await expect(
     page.getByText("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
@@ -205,4 +206,161 @@ test("upload posts the file body under the key", async ({ page }) => {
 
   await expect.poll(() => captured.uploads.length).toBe(1);
   expect(captured.uploads[0]).toEqual({ key: "firmware", body: "firmware-bytes" });
+});
+
+test("sort filter applies and resets to default", async ({ page }) => {
+  const versionQueries: string[] = [];
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const pathname = decodeURIComponent(url.pathname);
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/artifacts" && request.method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: stubArtifacts, next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/artifacts/spectra/versions") {
+      versionQueries.push(url.search);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: stubVersions, next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.goto("/en/operations/artifacts", { waitUntil: "domcontentloaded" });
+
+  // The sort filter lives in the versions view of a key. The card is one big
+  // link overlay (the anchor has no box; its inset span is the hit area).
+  await page.getByRole("link", { name: "Card link" }).locator("span").click();
+  await expect(page.getByText("application/vnd.oci.image.layer.v1.tar")).toBeVisible();
+
+  await page.getByRole("button", { name: "Sort", exact: true }).click();
+  await page.getByRole("option", { name: "Size" }).click();
+  await expect.poll(() => versionQueries.some((s) => s.includes("sort=size_bytes"))).toBe(true);
+
+  const sortedCount = versionQueries.length;
+  await page.getByRole("button", { name: "Sort", exact: true }).click();
+  await page.getByRole("option", { name: "Default" }).click();
+  await expect.poll(() => versionQueries.length).toBeGreaterThan(sortedCount);
+  expect(versionQueries[versionQueries.length - 1]!).not.toContain("sort=");
+});
+
+test("pagination moves next and back with cursors", async ({ page }) => {
+  const listQueries: string[] = [];
+
+  const summaryFor = (key: string) => ({
+    key,
+    version: `1.0.0-${key}`,
+    version_count: 1,
+    digest: `sha256:${key.repeat(64).slice(0, 64)}`,
+    size_bytes: 1_000_000,
+    source: `oci:ghcr.io/org/${key}:1`,
+    downloaded_at: iso(60_000),
+  });
+
+  const pageOne = { items: [summaryFor("a")], next_cursor: "c2", prev_cursor: null };
+  const pageTwo = { items: [summaryFor("b")], next_cursor: null, prev_cursor: "c1" };
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const pathname = decodeURIComponent(url.pathname);
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/artifacts" && request.method() === "GET") {
+      listQueries.push(url.search);
+      const cursor = url.searchParams.get("cursor");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        // Requests without a cursor and with the prev cursor both show page 1.
+        body: JSON.stringify(cursor === "c2" ? pageTwo : pageOne),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.goto("/en/operations/artifacts", { waitUntil: "domcontentloaded" });
+
+  // The header avatar fallback also shows a bare "a", so identify pages by
+  // the unique version string of the rendered card.
+  await expect(page.getByText("1.0.0-a", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "Next", exact: true }).click();
+  await expect.poll(() => listQueries.some((s) => s.includes("cursor=c2"))).toBe(true);
+  await expect(page.getByText("1.0.0-b", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "Previous", exact: true }).click();
+  await expect.poll(() => listQueries.some((s) => s.includes("cursor=c1"))).toBe(true);
+  await expect(page.getByText("1.0.0-a", { exact: true })).toBeVisible();
 });

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -14,7 +14,6 @@
     "done": "Fertig",
     "next": "Weiter",
     "noParameters": "Keine Parameter.",
-    "notImplemented": "Noch nicht implementiert.",
     "prev": "Zurück",
     "save": "Speichern",
     "rawJson": "JSON-Rohdaten",
@@ -77,7 +76,6 @@
       "role": "Rolle"
     },
     "users": {
-      "title": "Benutzer",
       "create": "Benutzer erstellen",
       "created": "Benutzer erstellt.",
       "createFailed": "Benutzer konnte nicht erstellt werden.",
@@ -89,7 +87,6 @@
       "mustChange": "Muss Passwort ändern"
     },
     "apiKeys": {
-      "title": "API-Schlüssel",
       "create": "API-Schlüssel erstellen",
       "created": "API-Schlüssel erstellt",
       "createFailed": "API-Schlüssel konnte nicht erstellt werden.",
@@ -105,8 +102,6 @@
   },
   "settings": {
     "title": "Einstellungen",
-    "description": "eCube-Präferenzen, Schwellenwerte und regionale Optionen anpassen.",
-    "saved": "Deine Einstellungen wurden gespeichert.",
     "nav": {
       "general": "Allgemein",
       "about": "Info",
@@ -134,7 +129,6 @@
       "about": {
         "title": "Info",
         "description": "Build-Informationen",
-        "version": "Version",
         "spectraVersion": "Spectra-Version",
         "apertureVersion": "Aperture-Version"
       }
@@ -162,19 +156,13 @@
       "title": "Logs",
       "body": "System-Logs ansehen und filtern, um Verhalten nachzuvollziehen und Probleme zu diagnostizieren.",
       "filters": {
-        "level": "Level",
-        "target": "Ziel",
         "targetAll": "Alle Ziele",
         "search": "Nachricht, Ziel oder Felder durchsuchen",
-        "timeRange": "Zeitbereich",
-        "fields": "Feldfilter",
         "fieldKey": "Schlüssel",
         "fieldValue": "Wert",
         "addField": "Feldfilter hinzufügen",
-        "removeField": "Entfernen",
         "hideFields": "Feldfilter ausblenden",
-        "clear": "Filter zurücksetzen",
-        "bootOnly": "Nur dieser Boot"
+        "clear": "Filter zurücksetzen"
       },
       "bootSelect": {
         "allBoots": "Alle Boots",
@@ -238,7 +226,6 @@
       "showAllSpans": "Alle Spans anzeigen",
       "events": "Ereignisse",
       "noEvents": "Keine Ereignisse in diesem Span",
-      "spanId": "Span",
       "childSpans": "Untergeordnete Spans",
       "noChildSpans": "Keine untergeordneten Spans"
     }
@@ -253,6 +240,7 @@
       "notStarted": "Nicht gestartet",
       "filters": {
         "statusAll": "Alle Status",
+        "status": "Status",
         "key": "Schlüssel",
         "keyAll": "Alle Schlüssel",
         "rootOnly": "Nur oberste Ebene"
@@ -302,7 +290,11 @@
       "updateFailed": "Zeitplan konnte nicht aktualisiert werden.",
       "deleted": "Zeitplan gelöscht.",
       "deleteFailed": "Zeitplan konnte nicht gelöscht werden.",
+      "deleteAction": "Zeitplan löschen",
+      "enabled": "Aktiviert",
       "interval": "Intervall",
+      "intervalUnit": "Einheit",
+      "intervalRaw": "Rohdauer (ISO 8601)",
       "nextRun": "Nächste Ausführung",
       "lastRun": "Letzte Ausführung",
       "never": "Nie",
@@ -331,9 +323,11 @@
       "evictFailed": "Version konnte nicht entfernt werden.",
       "filters": {
         "mediaType": "Medientyp",
-        "version": "Version"
+        "version": "Version",
+        "sort": "Sortierung"
       },
       "sort": {
+        "default": "Standard",
         "downloadedAt": "Zuletzt heruntergeladen",
         "sizeBytes": "Größe"
       }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -14,7 +14,6 @@
     "done": "Done",
     "next": "Next",
     "noParameters": "No parameters.",
-    "notImplemented": "Not implemented yet.",
     "prev": "Previous",
     "save": "Save",
     "rawJson": "Raw JSON",
@@ -77,7 +76,6 @@
       "role": "Role"
     },
     "users": {
-      "title": "Users",
       "create": "Create user",
       "created": "User created.",
       "createFailed": "Failed to create user.",
@@ -89,7 +87,6 @@
       "mustChange": "Must change password"
     },
     "apiKeys": {
-      "title": "API keys",
       "create": "Create API key",
       "created": "API key created",
       "createFailed": "Failed to create API key.",
@@ -105,8 +102,6 @@
   },
   "settings": {
     "title": "Settings",
-    "description": "Adjust eCube preferences, thresholds, and regional options.",
-    "saved": "Your settings have been saved.",
     "nav": {
       "general": "General",
       "about": "About",
@@ -134,7 +129,6 @@
       "about": {
         "title": "About",
         "description": "Build information",
-        "version": "Version",
         "spectraVersion": "Spectra version",
         "apertureVersion": "Aperture version"
       }
@@ -162,19 +156,13 @@
       "title": "Logs",
       "body": "View and filter system logs to trace behaviors and diagnose issues.",
       "filters": {
-        "level": "Level",
-        "target": "Target",
         "targetAll": "All targets",
         "search": "Search message, target, or fields",
-        "timeRange": "Time range",
-        "fields": "Field filter",
         "fieldKey": "Key",
         "fieldValue": "Value",
         "addField": "Add field filter",
-        "removeField": "Remove",
         "hideFields": "Hide field filter",
-        "clear": "Clear filters",
-        "bootOnly": "This boot only"
+        "clear": "Clear filters"
       },
       "bootSelect": {
         "allBoots": "All boots",
@@ -238,7 +226,6 @@
       "showAllSpans": "Show all spans",
       "events": "Events",
       "noEvents": "No events in this span",
-      "spanId": "Span",
       "childSpans": "Child spans",
       "noChildSpans": "No child spans"
     }
@@ -253,6 +240,7 @@
       "notStarted": "Not started",
       "filters": {
         "statusAll": "All statuses",
+        "status": "Status",
         "key": "Key",
         "keyAll": "All keys",
         "rootOnly": "Top-level only"
@@ -302,7 +290,11 @@
       "updateFailed": "Failed to update the schedule.",
       "deleted": "Schedule deleted.",
       "deleteFailed": "Failed to delete the schedule.",
+      "deleteAction": "Delete schedule",
+      "enabled": "Enabled",
       "interval": "Interval",
+      "intervalUnit": "Unit",
+      "intervalRaw": "Raw duration (ISO 8601)",
       "nextRun": "Next run",
       "lastRun": "Last run",
       "never": "Never",
@@ -331,9 +323,11 @@
       "evictFailed": "Failed to evict the version.",
       "filters": {
         "mediaType": "Media type",
-        "version": "Version"
+        "version": "Version",
+        "sort": "Sort"
       },
       "sort": {
+        "default": "Default",
         "downloadedAt": "Newest downloaded",
         "sizeBytes": "Size"
       }

--- a/modules/aperture/runtime/types.ts
+++ b/modules/aperture/runtime/types.ts
@@ -3,8 +3,6 @@ import type { components, operations } from "./generated";
 type Schemas = components["schemas"];
 
 export type VersionResponse = Schemas["VersionResponse"];
-export type OrderParam = Schemas["OrderParam"];
-export type VersionSortParam = Schemas["VersionSortParam"];
 export type LevelResponse = Schemas["LevelResponse"];
 
 export type RawLogEvent = Schemas["LogEventResponse"];
@@ -76,8 +74,6 @@ export type Setting = Schemas["SettingResponse"];
 
 export type TaskStatus = Schemas["TaskStatusResponse"];
 export type TaskStatusParam = Schemas["TaskStatusParam"];
-export type TaskProgress = Schemas["ProgressResponse"];
-export type TaskProgressMessage = Schemas["ProgressMessageResponse"];
 export type TaskDefinition = Schemas["TaskDefinitionResponse"];
 export type TaskDefinitionSummary = Schemas["TaskDefinitionSummary"];
 export type TaskDefinitionPage = Page<TaskDefinitionSummary>;


### PR DESCRIPTION
Fixes pager and polling races, create form state leaks, and the route query merge that dropped the artifacts key param. Adds the All keys and sort reset options, keyboard reachable artifact rows, aria-labels, and dead code cleanup. Updates the artifacts e2e selector for the new link rows and covers sort reset and cursor pagination there.

Stacked on #267.