### PR TITLE
test: filter codecs, schedules, and task cancel coverage

### DIFF
--- a/app/composables/useArtifactsFilters.ts
+++ b/app/composables/useArtifactsFilters.ts
@@ -21,7 +21,7 @@ const querySort = z.codec(z.array(z.string()), z.custom<ArtifactSort | undefined
   encode: (v) => (v ? [v] : []),
 });
 
-const artifactsSchema = z.object({
+export const artifactsSchema = z.object({
   q: queryOptionalString(),
   key: queryOptionalString(),
 });
@@ -38,7 +38,7 @@ export function artifactsParamsFromFilters(filters: ArtifactsFilters): ListArtif
   return p;
 }
 
-const versionsSchema = z.object({
+export const versionsSchema = z.object({
   media_type: queryOptionalString(),
   version: queryOptionalString(),
   sort: querySort,

--- a/e2e/schedules.spec.ts
+++ b/e2e/schedules.spec.ts
@@ -201,3 +201,128 @@ test("create schedule posts key, schema-driven input, and interval", async ({ pa
     interval: "PT10M",
   });
 });
+
+test("edit interval patches the new interval", async ({ page }) => {
+  const captured = { patches: [] as unknown[], creates: [] as unknown[] };
+  await stubSchedulesApi(page, captured);
+
+  let patchedInterval = "PT5M";
+  await page.route("**/api/v1/task-schedules/sched-1", async (route) => {
+    const patch = route.request().postDataJSON();
+    captured.patches.push(patch);
+    patchedInterval = patch.interval;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ...stubSchedule, interval: patch.interval }),
+    });
+  });
+
+  await page.route("**/api/v1/task-schedules", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [{ ...stubSchedule, interval: patchedInterval }],
+          next_cursor: null,
+          prev_cursor: null,
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.goto("/en/operations/schedules", { waitUntil: "domcontentloaded" });
+
+  await page.getByRole("button", { name: "Edit schedule" }).click();
+
+  const interval = page.getByRole("spinbutton");
+  await expect(interval).toHaveValue("5");
+  await interval.fill("10");
+  await expect(interval).toHaveValue("10");
+
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect.poll(() => captured.patches.length).toBe(1);
+  expect(captured.patches[0]).toEqual({ interval: "PT10M" });
+  await expect(page.getByText("10 min", { exact: true })).toBeVisible();
+});
+
+test("delete schedule fires delete and removes the row", async ({ page }) => {
+  const captured = { patches: [] as unknown[], creates: [] as unknown[] };
+  await stubSchedulesApi(page, captured);
+
+  const deletes: string[] = [];
+  await page.route("**/api/v1/task-schedules/sched-1", async (route) => {
+    if (route.request().method() !== "DELETE") {
+      await route.fallback();
+      return;
+    }
+    deletes.push(route.request().url());
+    await route.fulfill({ status: 204 });
+  });
+
+  await page.route("**/api/v1/task-schedules", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: deletes.length > 0 ? [] : [stubSchedule],
+          next_cursor: null,
+          prev_cursor: null,
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.goto("/en/operations/schedules", { waitUntil: "domcontentloaded" });
+  await expect(page.getByText("download", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "Delete schedule" }).click();
+
+  await expect.poll(() => deletes.length).toBe(1);
+  await expect(page.getByText("download", { exact: true })).toHaveCount(0);
+});
+
+test("sub-second interval edits through the raw input", async ({ page }) => {
+  const captured = { patches: [] as unknown[], creates: [] as unknown[] };
+  await stubSchedulesApi(page, captured);
+
+  const subSecondSchedule = { ...stubSchedule, interval: "PT0.5S" };
+
+  await page.route("**/api/v1/task-schedules", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [subSecondSchedule],
+          next_cursor: null,
+          prev_cursor: null,
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.goto("/en/operations/schedules", { waitUntil: "domcontentloaded" });
+  await expect(page.getByText("download", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "Edit schedule" }).click();
+
+  const raw = page.getByRole("textbox", { name: "Raw duration (ISO 8601)" });
+  await expect(raw).toHaveValue("PT0.5S");
+  await raw.fill("PT1S");
+  await expect(raw).toHaveValue("PT1S");
+
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect.poll(() => captured.patches.length).toBe(1);
+  expect(captured.patches[0]).toEqual({ interval: "PT1S" });
+});

--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -414,3 +414,277 @@ test("create task form is driven by the key schema", async ({ page }) => {
     },
   });
 });
+
+test("cancel rejection 409 shows not-cancellable toast", async ({ page }) => {
+  await page.route("**/api/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/tasks/task-2") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...stubDetail, input: ociInput }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/tasks") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/task-definitions") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: definitionSummaries, next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    const defMatch = pathname.match(/^\/api\/v1\/task-definitions\/(.+)$/);
+    if (defMatch) {
+      const definition = definitionFor(decodeURIComponent(defMatch[1]!));
+      if (!definition) {
+        await route.fulfill({ status: 404 });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(definition),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  // Registered after the catch-all, so this route takes precedence.
+  await page.route("**/api/v1/tasks/task-2/cancel", async (route) => {
+    await route.fulfill({ status: 409 });
+  });
+
+  await page.goto("/en/operations/tasks/task-2", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByRole("heading", { name: "download" })).toBeVisible();
+  await page.getByRole("button", { name: "Cancel task" }).click();
+  await expect(page.getByText("This task kind cannot be cancelled.")).toBeVisible();
+});
+
+test("cancel rejection 410 shows already-finished toast", async ({ page }) => {
+  await page.route("**/api/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/tasks/task-2") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...stubDetail, input: ociInput }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/tasks") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/task-definitions") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: definitionSummaries, next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    const defMatch = pathname.match(/^\/api\/v1\/task-definitions\/(.+)$/);
+    if (defMatch) {
+      const definition = definitionFor(decodeURIComponent(defMatch[1]!));
+      if (!definition) {
+        await route.fulfill({ status: 404 });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(definition),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  // Registered after the catch-all, so this route takes precedence.
+  await page.route("**/api/v1/tasks/task-2/cancel", async (route) => {
+    await route.fulfill({ status: 410 });
+  });
+
+  await page.goto("/en/operations/tasks/task-2", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByRole("heading", { name: "download" })).toBeVisible();
+  await page.getByRole("button", { name: "Cancel task" }).click();
+  await expect(page.getByText("This task has already finished.")).toBeVisible();
+});
+
+test("key filter selects and clears", async ({ page }) => {
+  const taskRequests: string[] = [];
+
+  await page.route("**/api/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+
+    if (pathname === "/api/v1/auth/setup-status") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ setup_required: false }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/auth/me") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          actor_id: "2",
+          user_id: "1",
+          display_name: "admin",
+          username: "admin",
+          roles: ["admin"],
+          must_change_password: false,
+        }),
+      });
+      return;
+    }
+
+    if (pathname === TASKS_PATH) {
+      taskRequests.push(url.search);
+      // No active tasks, so the 3s auto-refresh stays paused.
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [stubTasks[0]!], next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    if (pathname === "/api/v1/task-definitions") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: definitionSummaries, next_cursor: null, prev_cursor: null }),
+      });
+      return;
+    }
+
+    const defMatch = pathname.match(/^\/api\/v1\/task-definitions\/(.+)$/);
+    if (defMatch) {
+      const definition = definitionFor(decodeURIComponent(defMatch[1]!));
+      if (!definition) {
+        await route.fulfill({ status: 404 });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(definition),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.goto("/en/operations/tasks", { waitUntil: "domcontentloaded" });
+  await expect(page.getByText("download", { exact: true })).toBeVisible();
+
+  // Selecting a key reloads the list with key=<chosen>.
+  await page.getByRole("button", { name: "Key", exact: true }).click();
+  await page.getByRole("option", { name: "download" }).click();
+  await expect.poll(() => taskRequests.some((s) => s.includes("key=download"))).toBe(true);
+  await expect(page).toHaveURL(/key=download/);
+
+  // "All keys" drops the key from both request and URL.
+  const filteredCount = taskRequests.length;
+  await page.getByRole("button", { name: "Key", exact: true }).click();
+  await page.getByRole("option", { name: "All keys" }).click();
+  await expect.poll(() => taskRequests.length).toBeGreaterThan(filteredCount);
+  expect(taskRequests[taskRequests.length - 1]!).not.toContain("key=");
+  await expect(page).toHaveURL((url) => !url.searchParams.has("key"));
+});

--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -503,7 +503,9 @@ test("cancel rejection 409 shows not-cancellable toast", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "download" })).toBeVisible();
   await page.getByRole("button", { name: "Cancel task" }).click();
-  await expect(page.getByText("This task kind cannot be cancelled.")).toBeVisible();
+  await expect(
+    page.getByText("This task kind cannot be cancelled.", { exact: true }),
+  ).toBeVisible();
 });
 
 test("cancel rejection 410 shows already-finished toast", async ({ page }) => {
@@ -594,7 +596,7 @@ test("cancel rejection 410 shows already-finished toast", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "download" })).toBeVisible();
   await page.getByRole("button", { name: "Cancel task" }).click();
-  await expect(page.getByText("This task has already finished.")).toBeVisible();
+  await expect(page.getByText("This task has already finished.", { exact: true })).toBeVisible();
 });
 
 test("key filter selects and clears", async ({ page }) => {

--- a/test/filters.test.ts
+++ b/test/filters.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import * as z from "zod/v4/mini";
+import {
+  artifactsParamsFromFilters,
+  artifactsSchema,
+  versionsParamsFromFilters,
+  versionsSchema,
+  type ArtifactVersionsFilters,
+} from "~/composables/useArtifactsFilters";
+import {
+  tasksParamsFromFilters,
+  tasksSchema,
+  type TasksFilters,
+} from "~/composables/useTasksFilters";
+
+describe("tasksSchema", () => {
+  it("decodes a valid status", () => {
+    const actual = z.decode(tasksSchema, { status: ["failed"], key: [], root: [] });
+    expect(actual.status).toBe("failed");
+    expect(actual.key).toBeUndefined();
+    expect(actual.root).toBe(true);
+  });
+
+  it("falls back to undefined for an invalid status", () => {
+    const actual = z.decode(tasksSchema, { status: ["bogus"], key: [], root: [] });
+    expect(actual.status).toBeUndefined();
+  });
+
+  it("falls back to undefined for an empty status array", () => {
+    const actual = z.decode(tasksSchema, { status: [], key: [], root: [] });
+    expect(actual.status).toBeUndefined();
+  });
+
+  it("decodes key from a query value", () => {
+    const actual = z.decode(tasksSchema, { status: [], key: ["svc.backend"], root: [] });
+    expect(actual.key).toBe("svc.backend");
+  });
+
+  it("defaults root to true when the param is absent", () => {
+    const actual = z.decode(tasksSchema, { status: [], key: [], root: [] });
+    expect(actual.root).toBe(true);
+  });
+
+  it("decodes root from explicit 1/0 values", () => {
+    expect(z.decode(tasksSchema, { status: [], key: [], root: ["1"] }).root).toBe(true);
+    expect(z.decode(tasksSchema, { status: [], key: [], root: ["0"] }).root).toBe(false);
+  });
+
+  it("encodes root=true as ['1'] and root=false as ['0']", () => {
+    expect(z.encode(tasksSchema, { status: "active", key: "", root: true })).toEqual({
+      status: ["active"],
+      key: [],
+      root: ["1"],
+    });
+    expect(z.encode(tasksSchema, { status: "failed", key: "svc", root: false })).toEqual({
+      status: ["failed"],
+      key: ["svc"],
+      root: ["0"],
+    });
+  });
+
+  it("encodes unset status and key as empty arrays", () => {
+    expect(z.encode(tasksSchema, { status: undefined, key: undefined, root: true })).toEqual({
+      status: [],
+      key: [],
+      root: ["1"],
+    });
+  });
+
+  it("round trips through decode and encode", () => {
+    const filters = z.decode(tasksSchema, {
+      status: ["running"],
+      key: ["svc.backend"],
+      root: ["0"],
+    });
+    expect(z.encode(tasksSchema, filters)).toEqual({
+      status: ["running"],
+      key: ["svc.backend"],
+      root: ["0"],
+    });
+  });
+});
+
+describe("tasksParamsFromFilters", () => {
+  const empty: TasksFilters = { status: undefined, key: undefined, root: true };
+
+  it("propagates status, key, and root=true", () => {
+    expect(tasksParamsFromFilters({ ...empty, status: "pending", key: "cfg" })).toEqual({
+      status: "pending",
+      key: "cfg",
+      root: true,
+    });
+  });
+
+  it("propagates root=false without dropping it", () => {
+    expect(tasksParamsFromFilters({ ...empty, root: false })).toEqual({ root: false });
+  });
+
+  it("always emits root even when status and key are unset", () => {
+    expect(tasksParamsFromFilters(empty)).toEqual({ root: true });
+  });
+});
+
+describe("artifactsSchema", () => {
+  it("decodes q and key from single query values", () => {
+    const actual = z.decode(artifactsSchema, { q: ["foo"], key: ["bar"] });
+    expect(actual).toEqual({ q: "foo", key: "bar" });
+  });
+
+  it("decodes empty arrays to undefined", () => {
+    const actual = z.decode(artifactsSchema, { q: [], key: [] });
+    expect(actual.q).toBeUndefined();
+    expect(actual.key).toBeUndefined();
+  });
+
+  it("encodes set values and empty arrays for unset values", () => {
+    expect(z.encode(artifactsSchema, { q: "foo", key: undefined })).toEqual({
+      q: ["foo"],
+      key: [],
+    });
+    expect(z.encode(artifactsSchema, { q: undefined, key: undefined })).toEqual({
+      q: [],
+      key: [],
+    });
+  });
+});
+
+describe("versionsSchema", () => {
+  it("decodes a valid sort value", () => {
+    for (const sort of ["downloaded_at", "size_bytes"]) {
+      expect(z.decode(versionsSchema, { media_type: [], version: [], sort: [sort] }).sort).toBe(
+        sort,
+      );
+    }
+  });
+
+  it("falls back to undefined for an invalid sort value", () => {
+    const actual = z.decode(versionsSchema, { media_type: [], version: [], sort: ["bogus"] });
+    expect(actual.sort).toBeUndefined();
+  });
+
+  it("falls back to undefined for an empty sort array", () => {
+    const actual = z.decode(versionsSchema, { media_type: [], version: [], sort: [] });
+    expect(actual.sort).toBeUndefined();
+  });
+
+  it("encodes an undefined sort as an empty array", () => {
+    const encoded = z.encode(versionsSchema, {
+      media_type: undefined,
+      version: undefined,
+      sort: undefined,
+    });
+    expect(encoded.sort).toEqual([]);
+  });
+
+  it("encodes a valid sort value", () => {
+    const encoded = z.encode(versionsSchema, {
+      media_type: "application/octet-stream",
+      version: "v1",
+      sort: "size_bytes",
+    });
+    expect(encoded.sort).toEqual(["size_bytes"]);
+    expect(encoded.media_type).toEqual(["application/octet-stream"]);
+  });
+
+  it("decodes media_type and version alongside sort", () => {
+    const actual = z.decode(versionsSchema, {
+      media_type: ["application/octet-stream"],
+      version: ["v1.2"],
+      sort: [],
+    });
+    expect(actual.media_type).toBe("application/octet-stream");
+    expect(actual.version).toBe("v1.2");
+  });
+});
+
+describe("versionsParamsFromFilters", () => {
+  it("maps media_type, version, and sort", () => {
+    const filters: ArtifactVersionsFilters = {
+      media_type: "application/gzip",
+      version: "gz-1",
+      sort: "size_bytes",
+    };
+    expect(versionsParamsFromFilters(filters)).toEqual({
+      media_type: "application/gzip",
+      version: "gz-1",
+      sort: "size_bytes",
+    });
+  });
+
+  it("returns an empty params object when nothing is set", () => {
+    expect(
+      versionsParamsFromFilters({ media_type: undefined, version: undefined, sort: undefined }),
+    ).toEqual({});
+  });
+});
+
+describe("artifactsParamsFromFilters", () => {
+  it("maps q and drops key", () => {
+    expect(artifactsParamsFromFilters({ q: "foo", key: "bar" })).toEqual({ q: "foo" });
+  });
+
+  it("omits q when unset", () => {
+    expect(artifactsParamsFromFilters({ q: undefined, key: undefined })).toEqual({});
+  });
+});


### PR DESCRIPTION
Unit tests for the task and artifact filter codecs. E2e for schedule edit and delete, task cancel rejections, and key filter clearing. Writing these caught the pager guard and route query bugs fixed in the base PR.

Stacked on #268.